### PR TITLE
feat: add GET /api/transactions paginated endpoint (#28)

### DIFF
--- a/__tests__/api/transactions.test.ts
+++ b/__tests__/api/transactions.test.ts
@@ -1,0 +1,159 @@
+import { GET } from "@/app/api/transactions/route";
+import { NextRequest } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@/lib/prisma", () => ({
+	prisma: {
+		$transaction: jest.fn(),
+		gift: {
+			findMany: jest.fn(),
+			count: jest.fn(),
+		},
+	},
+}));
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+function makeRequest(
+	params: Record<string, string> = {},
+	userId: string | null = "user-123",
+) {
+	const url = new URL("http://localhost/api/transactions");
+	Object.entries(params).forEach(([k, v]) => url.searchParams.set(k, v));
+	const req = new NextRequest(url);
+	if (userId) req.headers.set("x-user-id", userId);
+	return req;
+}
+
+const mockGifts = [
+	{
+		id: "gift-1",
+		senderId: "user-123",
+		amount: 50,
+		currency: "USD",
+		status: "sent",
+		createdAt: new Date("2026-01-01"),
+		sender: { id: "user-123", name: "Sender", email: "sender@example.com" },
+		recipient: { id: "rec-1", name: "Alice", email: "alice@example.com" },
+	},
+	{
+		id: "gift-2",
+		senderId: "other-user",
+		amount: 75,
+		currency: "USD",
+		status: "confirmed",
+		createdAt: new Date("2026-01-02"),
+		sender: { id: "other-user", name: "Bob", email: "bob@example.com" },
+		recipient: { id: "user-123", name: "Me", email: "me@example.com" },
+	},
+];
+
+beforeEach(() => {
+	(mockPrisma.$transaction as jest.Mock).mockResolvedValue([mockGifts, 2]);
+});
+
+afterEach(() => jest.clearAllMocks());
+
+test("401 when unauthenticated", async () => {
+	const res = await GET(makeRequest({}, null));
+	expect(res.status).toBe(401);
+});
+
+test("400 on invalid type param", async () => {
+	const res = await GET(makeRequest({ type: "unknown" }));
+	expect(res.status).toBe(400);
+	const body = await res.json();
+	expect(body.error).toMatch(/type must be/);
+});
+
+test("400 on invalid page param", async () => {
+	const res = await GET(makeRequest({ page: "0" }));
+	expect(res.status).toBe(400);
+});
+
+test("400 on limit exceeding 100", async () => {
+	const res = await GET(makeRequest({ limit: "999" }));
+	expect(res.status).toBe(400);
+});
+
+test("returns paginated transactions with defaults", async () => {
+	const res = await GET(makeRequest());
+	expect(res.status).toBe(200);
+	const body = await res.json();
+	expect(body.total).toBe(2);
+	expect(body.page).toBe(1);
+	expect(body.limit).toBe(10);
+	expect(body.data).toHaveLength(2);
+	expect(body.data[0]).toMatchObject({
+		id: "gift-1",
+		recipient: { id: "rec-1", name: "Alice", email: "alice@example.com" },
+		amount: 50,
+		currency: "USD",
+		status: "sent",
+	});
+	expect(body.data[0].createdAt).toBe("2026-01-01T00:00:00.000Z");
+	expect(body.data[1]).toMatchObject({
+		id: "gift-2",
+		recipient: { id: "other-user", name: "Bob", email: "bob@example.com" },
+		amount: 75,
+		currency: "USD",
+		status: "confirmed",
+	});
+	expect(body.data[1].createdAt).toBe("2026-01-02T00:00:00.000Z");
+});
+
+test("type=sent filters by senderId", async () => {
+	await GET(makeRequest({ type: "sent" }));
+	expect(mockPrisma.gift.findMany).toHaveBeenCalledWith(
+		expect.objectContaining({
+			where: { senderId: "user-123" },
+		}),
+	);
+	expect(mockPrisma.gift.count).toHaveBeenCalledWith({
+		where: { senderId: "user-123" },
+	});
+});
+
+test("type=received filters by recipientId", async () => {
+	await GET(makeRequest({ type: "received" }));
+	expect(mockPrisma.gift.findMany).toHaveBeenCalledWith(
+		expect.objectContaining({
+			where: { recipientId: "user-123" },
+		}),
+	);
+	expect(mockPrisma.gift.count).toHaveBeenCalledWith({
+		where: { recipientId: "user-123" },
+	});
+});
+
+test("type=all returns both sent and received", async () => {
+	await GET(makeRequest({ type: "all" }));
+	expect(mockPrisma.gift.findMany).toHaveBeenCalledWith(
+		expect.objectContaining({
+			where: { OR: [{ senderId: "user-123" }, { recipientId: "user-123" }] },
+		}),
+	);
+	expect(mockPrisma.gift.count).toHaveBeenCalledWith({
+		where: { OR: [{ senderId: "user-123" }, { recipientId: "user-123" }] },
+	});
+});
+
+test("pagination params are respected", async () => {
+	await GET(makeRequest({ page: "2", limit: "5" }));
+	expect(mockPrisma.gift.findMany).toHaveBeenCalledWith(
+		expect.objectContaining({
+			skip: 5,
+			take: 5,
+		}),
+	);
+});
+
+test("400 on non-integer page param", async () => {
+	const res = await GET(makeRequest({ page: "1abc" }));
+	expect(res.status).toBe(400);
+});
+
+test("400 on non-integer limit param", async () => {
+	const res = await GET(makeRequest({ limit: "10.5" }));
+	expect(res.status).toBe(400);
+});

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,0 +1,108 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const ALLOWED_TYPES = ["sent", "received", "all"] as const;
+type TransactionType = (typeof ALLOWED_TYPES)[number];
+const INTEGER_PARAM_REGEX = /^\d+$/;
+
+const isValidPositiveInteger = (value: string): boolean =>
+	INTEGER_PARAM_REGEX.test(value) && Number.parseInt(value, 10) >= 1;
+
+export async function GET(request: NextRequest) {
+	// Auth — same pattern as gifts route
+	const userId = request.headers.get("x-user-id");
+	if (!userId) {
+		return NextResponse.json(
+			{ success: false, error: "Unauthorized" },
+			{ status: 401 },
+		);
+	}
+
+	const { searchParams } = request.nextUrl;
+
+	// Parse & validate query params
+	const typeParam = (searchParams.get("type") ?? "all") as TransactionType;
+	const pageParam = searchParams.get("page") ?? "1";
+	const limitParam = searchParams.get("limit") ?? "10";
+
+	if (!ALLOWED_TYPES.includes(typeParam)) {
+		return NextResponse.json(
+			{ success: false, error: "type must be one of: sent, received, all" },
+			{ status: 400 },
+		);
+	}
+
+	if (!isValidPositiveInteger(pageParam) || !isValidPositiveInteger(limitParam)) {
+		return NextResponse.json(
+			{
+				success: false,
+				error: "page must be >= 1 and limit must be between 1 and 100",
+			},
+			{ status: 400 },
+		);
+	}
+	const page = Number.parseInt(pageParam, 10);
+	const limit = Number.parseInt(limitParam, 10);
+	if (limit > 100) {
+		return NextResponse.json(
+			{
+				success: false,
+				error: "page must be >= 1 and limit must be between 1 and 100",
+			},
+			{ status: 400 },
+		);
+	}
+
+	// Build the WHERE clause based on type
+	const where =
+		typeParam === "sent"
+			? { senderId: userId }
+			: typeParam === "received"
+				? { recipientId: userId }
+				: { OR: [{ senderId: userId }, { recipientId: userId }] };
+
+	const [gifts, total] = await prisma.$transaction([
+		prisma.gift.findMany({
+			where,
+			skip: (page - 1) * limit,
+			take: limit,
+			orderBy: { createdAt: "desc" },
+			select: {
+				id: true,
+				senderId: true,
+				amount: true,
+				currency: true,
+				status: true,
+				createdAt: true,
+				sender: {
+					select: { id: true, name: true, email: true },
+				},
+				recipient: {
+					select: { id: true, name: true, email: true },
+				},
+			},
+		}),
+		prisma.gift.count({ where }),
+	]);
+
+	const transactions = gifts.map((gift) => {
+		const counterparty =
+			gift.senderId === userId ? gift.recipient : gift.sender;
+
+		return {
+			id: gift.id,
+			recipient: counterparty,
+			amount: gift.amount,
+			currency: gift.currency,
+			status: gift.status,
+			createdAt: gift.createdAt.toISOString(),
+		};
+	});
+
+	return NextResponse.json({
+		data: transactions,
+		total,
+		page,
+		limit,
+	});
+}

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,19 +1,25 @@
 export interface User {
-  id: string;
-  email: string;
-  name: string;
+	id: string;
+	email: string;
+	name: string;
 }
 
 export interface Transaction {
-  id: string;
-  amount: number;
-  currency: string;
-  status: "pending" | "completed" | "failed";
-  createdAt: string;
+	id: string;
+	recipient: {
+		id: string;
+		name: string | null;
+		email: string;
+	};
+
+	amount: number;
+	currency: string;
+	status: "pending_otp" | "confirmed" | "sent" | "failed";
+	createdAt: string;
 }
 
 export type ApiResponse<T> = {
-  data: T;
-  message?: string;
-  error?: string;
+	data: T;
+	message?: string;
+	error?: string;
 };


### PR DESCRIPTION
Closes #28

## Changes
- Added a new `GET /api/transactions` endpoint with `type`, `page`, and `limit` query params.
- Supports `?type=sent|received|all` filtering using `senderId` and `recipientId`.
- Returns paginated response: `{ data, total, page, limit }`.
- Each transaction item returns: `id`, `recipient`, `amount`, `currency`, `status`, `createdAt`.
- Uses `x-user-id` request header for auth and returns `401` when missing.
- Returns `400` for invalid query params:
  - invalid `type`
  - non-positive `page`
  - `limit` outside `1..100`
  - partially numeric values like `1abc` and decimal-like `10.5`
- Uses a single Prisma `$transaction` for `findMany + count`.

## Fixes from review
- Always selects both `sender` and `recipient` in query so the API can always resolve the counterparty.
  - This fixes received transactions previously showing only the current user in `recipient`.
- Added strict integer validation with `/^\d+$/` before parsing.
  - Prevents `parseInt`-style partial parsing from accepting invalid strings.
- Corrected `Transaction` typing:
  - `status` now aligns with `GiftStatus` values (`pending_otp | confirmed | sent | failed`)
  - `createdAt` is normalized to ISO string in API output.
- Strengthened tests:
  - Filter tests now assert exact Prisma `where` clauses for `sent`, `received`, and `all`.
  - Pagination test asserts `skip/take`.
  - Added tests for partially numeric invalid params.
