### PR TITLE
Add auth resend OTP and me endpoints

### DIFF
--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -1,0 +1,56 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthPayload } from "@/lib/auth-session";
+
+export async function GET(request: NextRequest) {
+  try {
+    const payload = getAuthPayload(request);
+    if (!payload) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: payload.userId },
+      select: {
+        id: true,
+        email: true,
+        name: true,
+        role: true,
+        status: true,
+        createdAt: true,
+        lastLogin: true,
+      },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "User not found" },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        user: {
+          ...user,
+          email_verified: user.status === "active",
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Error in auth/me:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Internal server error",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/auth/resend-otp/route.ts
+++ b/src/app/api/auth/resend-otp/route.ts
@@ -1,0 +1,114 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { getAuthPayload } from "@/lib/auth-session";
+import { generateOTP, storeOTP } from "@/server/services/otpService";
+import { sendVerificationEmail } from "@/server/services/emailService";
+
+const RESEND_COOLDOWN_MS = 60 * 1000;
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = getAuthPayload(request);
+    if (!payload) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const user = await prisma.user.findUnique({
+      where: { id: payload.userId },
+    });
+
+    if (!user) {
+      return NextResponse.json(
+        { success: false, error: "User not found" },
+        { status: 404 },
+      );
+    }
+
+    if (user.status === "active") {
+      console.log(
+        `[AUTH_AUDIT] OTP resend requested for verified user: ${user.id} from IP: ${
+          request.headers.get("x-forwarded-for")?.split(",")[0] || "127.0.0.1"
+        }`,
+      );
+      return NextResponse.json(
+        { success: true, message: "Email already verified" },
+        { status: 200 },
+      );
+    }
+
+    const latestVerification = await prisma.emailVerification.findFirst({
+      where: { userId: user.id },
+      orderBy: { createdAt: "desc" },
+      select: { createdAt: true },
+    });
+
+    const now = Date.now();
+    if (
+      latestVerification &&
+      now - latestVerification.createdAt.getTime() < RESEND_COOLDOWN_MS
+    ) {
+      const retryAfterSeconds = Math.ceil(
+        (RESEND_COOLDOWN_MS -
+          (now - latestVerification.createdAt.getTime())) /
+          1000,
+      );
+
+      console.log(
+        `[AUTH_AUDIT] OTP resend rate limited for user: ${user.id} from IP: ${
+          request.headers.get("x-forwarded-for")?.split(",")[0] || "127.0.0.1"
+        }`,
+      );
+
+      return NextResponse.json(
+        {
+          success: false,
+          error: "Rate limit exceeded",
+          message: "Please wait before requesting a new verification code.",
+          retryAfter: retryAfterSeconds,
+        },
+        { status: 429 },
+      );
+    }
+
+    const otp = generateOTP();
+    await storeOTP(user.id, otp);
+
+    const emailResult = await sendVerificationEmail(
+      user.email,
+      otp,
+      user.name || undefined,
+    );
+
+    if (!emailResult.success) {
+      console.error(
+        `[AUTH_AUDIT] OTP resend email failed for user: ${user.id}`,
+        emailResult.error,
+      );
+    }
+
+    console.log(
+      `[AUTH_AUDIT] OTP resent for user: ${user.id} from IP: ${
+        request.headers.get("x-forwarded-for")?.split(",")[0] || "127.0.0.1"
+      }`,
+    );
+
+    return NextResponse.json({
+      success: true,
+      message: "New verification code sent successfully",
+      expiresIn: "10 minutes",
+    });
+  } catch (error) {
+    console.error("Error in resend-otp:", error);
+    return NextResponse.json(
+      {
+        success: false,
+        error: "Internal server error",
+        message: error instanceof Error ? error.message : "Unknown error",
+      },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/auth-session.ts
+++ b/src/lib/auth-session.ts
@@ -1,0 +1,20 @@
+import { NextRequest } from "next/server";
+import { verifyAccessToken, type TokenPayload } from "@/lib/tokens";
+
+export function getAuthPayload(
+  request: Request | NextRequest,
+): TokenPayload | null {
+  const header =
+    request.headers.get("authorization") ||
+    request.headers.get("Authorization");
+  if (!header) {
+    return null;
+  }
+
+  const [scheme, token] = header.split(" ");
+  if (!token || scheme.toLowerCase() !== "bearer") {
+    return null;
+  }
+
+  return verifyAccessToken(token);
+}

--- a/swagger.yaml
+++ b/swagger.yaml
@@ -216,6 +216,71 @@ paths:
         "401":
           description: Unauthorized
 
+  /api/auth/resend-otp:
+    post:
+      summary: Resend email verification OTP
+      description: Resends a verification code to the authenticated user with a 60 second cooldown.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: OTP resent successfully or already verified
+        "401":
+          description: Unauthorized
+        "404":
+          description: User not found
+        "429":
+          description: Rate limit exceeded
+        "500":
+          description: Internal server error
+
+  /api/auth/me:
+    get:
+      summary: Get current user
+      description: Returns the authenticated user's profile and verification status.
+      security:
+        - bearerAuth: []
+      responses:
+        "200":
+          description: User returned successfully
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  success:
+                    type: boolean
+                  user:
+                    type: object
+                    properties:
+                      id:
+                        type: string
+                      email:
+                        type: string
+                        format: email
+                      name:
+                        type: string
+                        nullable: true
+                      role:
+                        type: string
+                      status:
+                        type: string
+                      createdAt:
+                        type: string
+                        format: date-time
+                      lastLogin:
+                        type: string
+                        format: date-time
+                        nullable: true
+                      email_verified:
+                        type: boolean
+        "401":
+          description: Unauthorized
+        "404":
+          description: User not found
+        "500":
+          description: Internal server error
+
 components:
   securitySchemes:
     bearerAuth:


### PR DESCRIPTION
Closes #44

---

Implements authenticated endpoints for resending email verification OTPs with a 60s cooldown and for fetching the current user’s verification status.

  Changes

  - Add POST /api/auth/resend-otp with 60s rate limit, OTP invalidation, and audit logging.
  - Add GET /api/auth/me returning user info plus email_verified.
  - Add shared auth token parser.
  - Update swagger.yaml documentation.

  Acceptance Criteria

  - POST /api/auth/resend-otp returns 429 if called within 60 seconds of last OTP.
  - New OTP invalidates previous one.
  - GET /api/auth/me includes email_verified boolean.
  - Both endpoints require a valid auth token.
  - Resend attempts are logged for audit.