### PR TITLE
done with the reset password task

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@stellar/stellar-sdk": "^14.4.3",
         "@tailwindcss/postcss": "^4.1.18",
         "bcryptjs": "^3.0.3",
+        "drizzle-orm": "^0.45.1",
         "framer-motion": "^12.29.0",
         "jsonwebtoken": "^9.0.3",
         "lucide-react": "^0.563.0",
@@ -39,6 +40,7 @@
         "eslint": "^9",
         "eslint-config-next": "16.1.2",
         "jest": "^30.2.0",
+        "jest-regex-util": "^30.0.1",
         "ts-jest": "^29.4.6",
         "typescript": "^5"
       }
@@ -93,6 +95,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -2086,6 +2089,7 @@
       "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -2675,6 +2679,7 @@
       "integrity": "sha512-WJtwWJu7UdlvzEAUm484QNg5eAoq5QR08KDNx7g45Usrs2NtOPiX8ugDqmKdXkyL03rBqU5dYNYVQetEpBHq2g==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "undici-types": "~6.21.0"
       }
@@ -2705,6 +2710,7 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2788,6 +2794,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3294,6 +3301,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3693,6 +3701,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -3848,6 +3857,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -4551,6 +4561,131 @@
         "url": "https://dotenvx.com"
       }
     },
+    "node_modules/drizzle-orm": {
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/drizzle-orm/-/drizzle-orm-0.45.1.tgz",
+      "integrity": "sha512-Te0FOdKIistGNPMq2jscdqngBRfBpC8uMFVwqjf6gtTVJHIQ/dosgV/CLBU2N4ZJBsXL5savCba9b0YJskKdcA==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@aws-sdk/client-rds-data": ">=3",
+        "@cloudflare/workers-types": ">=4",
+        "@electric-sql/pglite": ">=0.2.0",
+        "@libsql/client": ">=0.10.0",
+        "@libsql/client-wasm": ">=0.10.0",
+        "@neondatabase/serverless": ">=0.10.0",
+        "@op-engineering/op-sqlite": ">=2",
+        "@opentelemetry/api": "^1.4.1",
+        "@planetscale/database": ">=1.13",
+        "@prisma/client": "*",
+        "@tidbcloud/serverless": "*",
+        "@types/better-sqlite3": "*",
+        "@types/pg": "*",
+        "@types/sql.js": "*",
+        "@upstash/redis": ">=1.34.7",
+        "@vercel/postgres": ">=0.8.0",
+        "@xata.io/client": "*",
+        "better-sqlite3": ">=7",
+        "bun-types": "*",
+        "expo-sqlite": ">=14.0.0",
+        "gel": ">=2",
+        "knex": "*",
+        "kysely": "*",
+        "mysql2": ">=2",
+        "pg": ">=8",
+        "postgres": ">=3",
+        "sql.js": ">=1",
+        "sqlite3": ">=5"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/client-rds-data": {
+          "optional": true
+        },
+        "@cloudflare/workers-types": {
+          "optional": true
+        },
+        "@electric-sql/pglite": {
+          "optional": true
+        },
+        "@libsql/client": {
+          "optional": true
+        },
+        "@libsql/client-wasm": {
+          "optional": true
+        },
+        "@neondatabase/serverless": {
+          "optional": true
+        },
+        "@op-engineering/op-sqlite": {
+          "optional": true
+        },
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@planetscale/database": {
+          "optional": true
+        },
+        "@prisma/client": {
+          "optional": true
+        },
+        "@tidbcloud/serverless": {
+          "optional": true
+        },
+        "@types/better-sqlite3": {
+          "optional": true
+        },
+        "@types/pg": {
+          "optional": true
+        },
+        "@types/sql.js": {
+          "optional": true
+        },
+        "@upstash/redis": {
+          "optional": true
+        },
+        "@vercel/postgres": {
+          "optional": true
+        },
+        "@xata.io/client": {
+          "optional": true
+        },
+        "better-sqlite3": {
+          "optional": true
+        },
+        "bun-types": {
+          "optional": true
+        },
+        "expo-sqlite": {
+          "optional": true
+        },
+        "gel": {
+          "optional": true
+        },
+        "knex": {
+          "optional": true
+        },
+        "kysely": {
+          "optional": true
+        },
+        "mysql2": {
+          "optional": true
+        },
+        "pg": {
+          "optional": true
+        },
+        "postgres": {
+          "optional": true
+        },
+        "prisma": {
+          "optional": true
+        },
+        "sql.js": {
+          "optional": true
+        },
+        "sqlite3": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
@@ -4852,6 +4987,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5037,6 +5173,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -6793,6 +6930,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -8931,6 +9069,7 @@
       "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -9215,6 +9354,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9224,6 +9364,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10337,6 +10478,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -10627,6 +10769,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11159,6 +11302,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@stellar/stellar-sdk": "^14.4.3",
     "@tailwindcss/postcss": "^4.1.18",
     "bcryptjs": "^3.0.3",
+    "drizzle-orm": "^0.45.1",
     "framer-motion": "^12.29.0",
     "jsonwebtoken": "^9.0.3",
     "lucide-react": "^0.563.0",
@@ -41,6 +42,7 @@
     "eslint": "^9",
     "eslint-config-next": "16.1.2",
     "jest": "^30.2.0",
+    "jest-regex-util": "^30.0.1",
     "ts-jest": "^29.4.6",
     "typescript": "^5"
   }

--- a/src/server/db/authRepository.ts
+++ b/src/server/db/authRepository.ts
@@ -1,0 +1,137 @@
+import { and, eq } from "drizzle-orm";
+import { db } from "./drizzle";
+import { passwordResets, refreshTokens, users } from "./schema";
+
+export interface RegisterUserInput {
+  email: string;
+  passwordHash: string;
+  name?: string | null;
+}
+
+export interface AuthUser {
+  id: string;
+  email: string;
+  name: string | null;
+  role: string;
+  status: string;
+}
+
+export interface PasswordResetRequest {
+  id: string;
+  userId: string;
+  expiresAt: Date;
+  usedAt: Date | null;
+  user: {
+    email: string;
+    name: string | null;
+  };
+}
+
+function toDate(value: string): Date {
+  return new Date(value);
+}
+
+function toDateString(date: Date): string {
+  return date.toISOString();
+}
+
+export async function findUserByEmail(email: string): Promise<AuthUser | null> {
+  const [user] = await db
+    .select({
+      id: users.id,
+      email: users.email,
+      name: users.name,
+      role: users.role,
+      status: users.status,
+    })
+    .from(users)
+    .where(eq(users.email, email))
+    .limit(1);
+
+  return user ?? null;
+}
+
+export async function createUser(input: RegisterUserInput): Promise<AuthUser> {
+  const now = toDateString(new Date());
+  const userId = crypto.randomUUID();
+
+  await db.insert(users).values({
+    id: userId,
+    email: input.email,
+    passwordHash: input.passwordHash,
+    name: input.name ?? null,
+    role: "user",
+    status: "unverified",
+    loginAttempts: 0,
+    lockUntil: null,
+    createdAt: now,
+    updatedAt: now,
+    lastLogin: null,
+  });
+
+  return {
+    id: userId,
+    email: input.email,
+    name: input.name ?? null,
+    role: "user",
+    status: "unverified",
+  };
+}
+
+export async function findPasswordResetByToken(
+  token: string,
+): Promise<PasswordResetRequest | null> {
+  const [record] = await db
+    .select({
+      id: passwordResets.id,
+      userId: passwordResets.userId,
+      expiresAt: passwordResets.expiresAt,
+      usedAt: passwordResets.usedAt,
+      email: users.email,
+      name: users.name,
+    })
+    .from(passwordResets)
+    .innerJoin(users, eq(users.id, passwordResets.userId))
+    .where(eq(passwordResets.token, token))
+    .limit(1);
+
+  if (!record) {
+    return null;
+  }
+
+  return {
+    id: record.id,
+    userId: record.userId,
+    expiresAt: toDate(record.expiresAt),
+    usedAt: record.usedAt ? toDate(record.usedAt) : null,
+    user: {
+      email: record.email,
+      name: record.name ?? null,
+    },
+  };
+}
+
+export async function completePasswordReset(input: {
+  resetId: string;
+  userId: string;
+  passwordHash: string;
+}): Promise<void> {
+  const now = toDateString(new Date());
+
+  await db
+    .update(users)
+    .set({
+      passwordHash: input.passwordHash,
+      updatedAt: now,
+    })
+    .where(eq(users.id, input.userId));
+
+  await db
+    .update(passwordResets)
+    .set({ usedAt: now })
+    .where(
+      and(eq(passwordResets.id, input.resetId), eq(passwordResets.userId, input.userId)),
+    );
+
+  await db.delete(refreshTokens).where(eq(refreshTokens.userId, input.userId));
+}

--- a/src/server/db/drizzle.ts
+++ b/src/server/db/drizzle.ts
@@ -1,0 +1,30 @@
+import { prisma } from "@/lib/prisma";
+import { drizzle, type AsyncRemoteCallback } from "drizzle-orm/sqlite-proxy";
+import * as schema from "./schema";
+
+const sqliteProxyCallback: AsyncRemoteCallback = async (
+  sql,
+  params,
+  method,
+) => {
+  if (method === "run") {
+    await prisma.$executeRawUnsafe(sql, ...params);
+    return { rows: [] };
+  }
+
+  const rows = (await prisma.$queryRawUnsafe(sql, ...params)) as unknown[];
+  return { rows };
+};
+
+const createDb = () => drizzle(sqliteProxyCallback, { schema });
+type DrizzleDb = ReturnType<typeof createDb>;
+
+const globalForDrizzle = globalThis as unknown as {
+  drizzleDb?: DrizzleDb;
+};
+
+export const db = globalForDrizzle.drizzleDb ?? createDb();
+
+if (process.env.NODE_ENV !== "production") {
+  globalForDrizzle.drizzleDb = db;
+}

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -1,0 +1,35 @@
+import { integer, sqliteTable, text } from "drizzle-orm/sqlite-core";
+
+export const users = sqliteTable("User", {
+  id: text("id").primaryKey(),
+  email: text("email").notNull(),
+  passwordHash: text("passwordHash").notNull(),
+  name: text("name"),
+  role: text("role").notNull(),
+  status: text("status").notNull(),
+  loginAttempts: integer("loginAttempts").notNull(),
+  lockUntil: text("lockUntil"),
+  createdAt: text("createdAt").notNull(),
+  updatedAt: text("updatedAt").notNull(),
+  lastLogin: text("lastLogin"),
+});
+
+export const passwordResets = sqliteTable("PasswordReset", {
+  id: text("id").primaryKey(),
+  userId: text("userId").notNull(),
+  token: text("token").notNull(),
+  expiresAt: text("expiresAt").notNull(),
+  createdAt: text("createdAt").notNull(),
+  usedAt: text("usedAt"),
+  ipAddress: text("ipAddress"),
+});
+
+export const refreshTokens = sqliteTable("RefreshToken", {
+  id: text("id").primaryKey(),
+  userId: text("userId").notNull(),
+  token: text("token").notNull(),
+  expiresAt: text("expiresAt").notNull(),
+  createdAt: text("createdAt").notNull(),
+  revokedAt: text("revokedAt"),
+  deviceInfo: text("deviceInfo"),
+});


### PR DESCRIPTION
This pull request refactors the authentication backend to use a new `authRepository` built with Drizzle ORM, replacing direct Prisma access in registration and password reset flows. It also updates related tests and introduces new dependencies. The most important changes are grouped below:

**Authentication Logic Refactor:**

* Introduced a new `authRepository` (`src/server/db/authRepository.ts`) that implements user registration, user lookup, password reset token lookup, and password reset completion using Drizzle ORM instead of direct Prisma calls. This centralizes and abstracts database logic for authentication.
* Refactored the registration (`src/app/api/auth/register/route.ts`) and password reset (`src/app/api/auth/reset-password/route.ts`) API routes to use the new repository functions (`findUserByEmail`, `createUser`, `findPasswordResetByToken`, `completePasswordReset`) and to hash passwords directly with bcrypt at a cost of 12. [[1]](diffhunk://#diff-faf2ad5f2f764a35e19d13b4535c536e617c88af5e2e0d4151e6b68e0c36a20dL2-R13) [[2]](diffhunk://#diff-faf2ad5f2f764a35e19d13b4535c536e617c88af5e2e0d4151e6b68e0c36a20dL95-R99) [[3]](diffhunk://#diff-faf2ad5f2f764a35e19d13b4535c536e617c88af5e2e0d4151e6b68e0c36a20dL107-R131) [[4]](diffhunk://#diff-faf2ad5f2f764a35e19d13b4535c536e617c88af5e2e0d4151e6b68e0c36a20dR140) [[5]](diffhunk://#diff-5276c37c0c4d1896edaf393c4b478dd3c5aa57f07e87fec8f496b3f212668c17L2-R20) [[6]](diffhunk://#diff-5276c37c0c4d1896edaf393c4b478dd3c5aa57f07e87fec8f496b3f212668c17L28-R34) [[7]](diffhunk://#diff-5276c37c0c4d1896edaf393c4b478dd3c5aa57f07e87fec8f496b3f212668c17L42-R48) [[8]](diffhunk://#diff-5276c37c0c4d1896edaf393c4b478dd3c5aa57f07e87fec8f496b3f212668c17L68-R77)

**Database Layer Integration:**

* Added a Drizzle ORM database instance (`src/server/db/drizzle.ts`) that proxies SQL statements to Prisma, enabling the use of Drizzle's query builder and schema while maintaining compatibility with the existing Prisma setup.

**Testing Updates:**

* Updated registration and password reset tests to mock and use the new repository and service functions, removing direct Prisma and custom hash mocks, and verifying the correct flow (including OTP and email verification). [[1]](diffhunk://#diff-7358458292905312efe93dfc65dc3810058f1ac051d3e7cbfe0bc8bede6e89a1L2-R52) [[2]](diffhunk://#diff-7358458292905312efe93dfc65dc3810058f1ac051d3e7cbfe0bc8bede6e89a1L46-R85) [[3]](diffhunk://#diff-7358458292905312efe93dfc65dc3810058f1ac051d3e7cbfe0bc8bede6e89a1R101) [[4]](diffhunk://#diff-ae77e2cd90906d1fd490fce6e5d542fe5530160db67ca28b890f8ceb7b2dbdc3R2-R19) [[5]](diffhunk://#diff-ae77e2cd90906d1fd490fce6e5d542fe5530160db67ca28b890f8ceb7b2dbdc3R34-R76) [[6]](diffhunk://#diff-ae77e2cd90906d1fd490fce6e5d542fe5530160db67ca28b890f8ceb7b2dbdc3L95-R89) [[7]](diffhunk://#diff-ae77e2cd90906d1fd490fce6e5d542fe5530160db67ca28b890f8ceb7b2dbdc3L111-R110) [[8]](diffhunk://#diff-ae77e2cd90906d1fd490fce6e5d542fe5530160db67ca28b890f8ceb7b2dbdc3L138-R131)

**Dependency Management:**

* Added `drizzle-orm` and `jest-regex-util` as new dependencies in `package.json` to support the new database layer and enhance testing utilities. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17) [[2]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R45)

These changes lay the groundwork for a more maintainable and testable authentication system by decoupling business logic from direct database access and improving the structure of tests.

Closes #45 