### PR TITLE
feat: Review Gift Details API Endpoint

### DIFF
--- a/__tests__/api/gifts/get-gift-details.test.ts
+++ b/__tests__/api/gifts/get-gift-details.test.ts
@@ -1,0 +1,127 @@
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/gifts/[giftId]/route";
+import { prisma } from "@/lib/prisma";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    gift: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+const mockPrisma = prisma as jest.Mocked<typeof prisma>;
+
+const mockGift = {
+  id: "gift-123",
+  senderId: "sender-123",
+  recipientId: "recipient-456",
+  amount: 150,
+  currency: "USD",
+  message: "Happy birthday!",
+  template: "birthday",
+  status: "pending_otp",
+  recipient: {
+    id: "recipient-456",
+    name: "Recipient User",
+    email: "recipient@example.com",
+  },
+};
+
+function makeRequest(giftId: string, userId?: string) {
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (userId) {
+    headers["x-user-id"] = userId;
+  }
+
+  return new NextRequest(`http://localhost/api/gifts/${giftId}`, {
+    method: "GET",
+    headers,
+  });
+}
+
+describe("GET /api/gifts/:giftId", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 200 with full gift details for creator", async () => {
+    (mockPrisma.gift.findUnique as jest.Mock).mockResolvedValue(mockGift);
+
+    const response = await GET(makeRequest("gift-123", "sender-123"), {
+      params: Promise.resolve({ giftId: "gift-123" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toEqual({
+      id: "gift-123",
+      recipient: {
+        id: "recipient-456",
+        name: "Recipient User",
+        email: "recipient@example.com",
+      },
+      amount: 150,
+      currency: "USD",
+      message: "Happy birthday!",
+      template: "birthday",
+      status: "pending_otp",
+    });
+  });
+
+  it("should return 401 when unauthenticated", async () => {
+    const response = await GET(makeRequest("gift-123"), {
+      params: Promise.resolve({ giftId: "gift-123" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Unauthorized");
+  });
+
+  it("should return 404 when gift does not exist", async () => {
+    (mockPrisma.gift.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(makeRequest("gift-999", "sender-123"), {
+      params: Promise.resolve({ giftId: "gift-999" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Gift not found");
+  });
+
+  it("should return 403 when requester is not the gift creator", async () => {
+    (mockPrisma.gift.findUnique as jest.Mock).mockResolvedValue(mockGift);
+
+    const response = await GET(makeRequest("gift-123", "other-user-000"), {
+      params: Promise.resolve({ giftId: "gift-123" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(403);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Forbidden");
+  });
+
+  it("should return 404 when gift status is not reviewable", async () => {
+    (mockPrisma.gift.findUnique as jest.Mock).mockResolvedValue({
+      ...mockGift,
+      status: "completed",
+    });
+
+    const response = await GET(makeRequest("gift-123", "sender-123"), {
+      params: Promise.resolve({ giftId: "gift-123" }),
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Gift not found");
+  });
+});

--- a/src/app/api/gifts/[giftId]/route.ts
+++ b/src/app/api/gifts/[giftId]/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+
+const REVIEWABLE_GIFT_STATUSES = new Set(["pending_otp", "otp_verified"]);
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ giftId: string }> },
+) {
+  try {
+    const userId = request.headers.get("x-user-id");
+
+    if (!userId) {
+      return NextResponse.json(
+        { success: false, error: "Unauthorized" },
+        { status: 401 },
+      );
+    }
+
+    const { giftId } = await params;
+
+    const gift = await prisma.gift.findUnique({
+      where: { id: giftId },
+      include: {
+        recipient: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+      },
+    });
+
+    if (!gift) {
+      return NextResponse.json(
+        { success: false, error: "Gift not found" },
+        { status: 404 },
+      );
+    }
+
+    if (gift.senderId !== userId) {
+      return NextResponse.json(
+        { success: false, error: "Forbidden" },
+        { status: 403 },
+      );
+    }
+
+    if (!REVIEWABLE_GIFT_STATUSES.has(gift.status)) {
+      return NextResponse.json(
+        { success: false, error: "Gift not found" },
+        { status: 404 },
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          id: gift.id,
+          recipient: gift.recipient,
+          amount: gift.amount,
+          currency: gift.currency,
+          message: gift.message,
+          template: gift.template,
+          status: gift.status,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Error fetching gift details:", error);
+    return NextResponse.json(
+      { success: false, error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}


### PR DESCRIPTION
closes #31 

This PR introduces a new authenticated endpoint that allows a gift creator to fetch full details of their pending gift for the review screen.

What’s Included

Added GET /api/gifts/:giftId route.

Fetches full gift details (recipient info, amount, currency, message, template, status).

Enforces access control: only the creator of the gift can view it.

Validates gift existence and returns:

403 if the requester is not the creator.

404 if the gift does not exist.

Restricts access to gifts with status pending_otp or otp_verified only.

Requires valid authentication.