### PR TITLE
feat(auth): add Login page with two-panel layout and Forgot password link

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -95,6 +95,7 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -1832,6 +1833,7 @@
       "resolved": "https://registry.npmjs.org/@libsql/client/-/client-0.17.0.tgz",
       "integrity": "sha512-TLjSU9Otdpq0SpKHl1tD1Nc9MKhrsZbCFGot3EbCxRa8m1E5R1mMwoOjKMMM31IyF7fr+hPNHLpYfwbMKNusmg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@libsql/core": "^0.17.0",
         "@libsql/hrana-client": "^0.9.0",
@@ -2255,6 +2257,7 @@
       "integrity": "sha512-gR2EMvfK/aTxsuooaDA32D8v+us/8AAet+C3J1cc04SW35FPdZYgLF+iN4NDLUgAaUGTKdAB0CYenu1TAgGdMg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "engines": {
         "node": ">=18.18"
       },
@@ -2873,6 +2876,7 @@
       "integrity": "sha512-WPigyYuGhgZ/cTPRXB2EwUw+XvsRA3GqHlsP4qteqrnnjDrApbS7MxcGr/hke5iUoeB7E/gQtrs9I37zAJ0Vjw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -2965,6 +2969,7 @@
       "integrity": "sha512-BtE0k6cjwjLZoZixN0t5AKP0kSzlGu7FctRXYuPAm//aaiZhmfq1JwdYpYr1brzEspYyFeF+8XF5j2VK6oalrA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.54.0",
         "@typescript-eslint/types": "8.54.0",
@@ -3471,6 +3476,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -3870,6 +3876,7 @@
       "integrity": "sha512-Ixm8tFfoKKIPYdCCKYTsqv+Fd4IJ0DQqMyEimo+pxUOMUR9cVPlwTrFt9Avu+3cb6Zp3mAzl+t1MrG2fxxKsxw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/types": "^7.26.0"
       }
@@ -4025,6 +4032,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5192,6 +5200,7 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -5377,6 +5386,7 @@
       "integrity": "sha512-whOE1HFo/qJDyX4SnXzP4N6zOWn79WhnCUY/iDR0mPfQZO8wcYE4JClzI2oZrhBnnMUCBCHZhO6VQyoBU95mZA==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.9",
@@ -7168,6 +7178,7 @@
       "integrity": "sha512-F26gjC0yWN8uAA5m5Ss8ZQf5nDHWGlN/xWZIh8S5SRbsEKBovwZhxGd6LJlbZYxBgCYOtreSUyb8hpXyGC5O4A==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "30.2.0",
         "@jest/types": "30.2.0",
@@ -9391,6 +9402,7 @@
       "integrity": "sha512-XTKeKxtQElcq3U9/jHyxSPgiRgeYDKxWTPOf6NkXA0dNj5j40MfEsZkMbyNpwDWCUv7YBFUl7I2VK/6ALbmhEg==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/config": "6.19.2",
         "@prisma/engines": "6.19.2"
@@ -9681,6 +9693,7 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9690,6 +9703,7 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10803,6 +10817,7 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -11099,6 +11114,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "devOptional": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -11676,6 +11692,7 @@
       "integrity": "sha512-rftlrkhHZOcjDwkGlnUtZZkvaPHCsDATp4pGpuOOMDaTdDDXF91wuVDJoWoPsKX/3YPQ5fHuF3STjcYyKr+Qhg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/app/auth/login/page.tsx
+++ b/src/app/auth/login/page.tsx
@@ -1,8 +1,13 @@
 "use client";
 
 import React, { Suspense, useState } from "react";
+import Link from "next/link";
 import { useRouter, useSearchParams } from "next/navigation";
 import { useAuthContext } from "@/context/AuthContext";
+import { AuthLayout } from "@/layouts/AuthLayout";
+import { WorldMapShowcase } from "@/components/auth/WordMapShowcase";
+import { Input } from "@/components/Input";
+import { PasswordInput } from "@/components/PasswordInput";
 import Button from "@/components/Button";
 
 function LoginForm() {
@@ -22,7 +27,6 @@ function LoginForm() {
     try {
       await login(email, password);
       const callbackUrl = searchParams.get("callbackUrl");
-      // Validate callbackUrl is a relative path to prevent open redirects
       const redirectTo =
         callbackUrl && callbackUrl.startsWith("/")
           ? callbackUrl
@@ -36,38 +40,86 @@ function LoginForm() {
   };
 
   return (
-    <form onSubmit={handleSubmit} className="w-full max-w-sm space-y-4">
-      {error && <p className="text-red-500 text-sm">{error}</p>}
-      <input
-        type="email"
-        placeholder="Email address"
-        className="w-full p-2 border rounded"
-        value={email}
-        onChange={(e) => setEmail(e.target.value)}
-        required
-      />
-      <input
-        type="password"
-        placeholder="Password"
-        className="w-full p-2 border rounded"
-        value={password}
-        onChange={(e) => setPassword(e.target.value)}
-        required
-      />
-      <Button className="w-full" disabled={isSubmitting}>
-        {isSubmitting ? "Signing in..." : "Sign In"}
-      </Button>
-    </form>
+    <div className="space-y-7 max-w-sm">
+      <div className="gap-0.5 flex flex-col">
+        <h1 className="text-lg md:text-xl font-bold text-[#18181B] leading-tight">
+          Login.
+        </h1>
+        <p className="text-xs text-[#717182]">
+          To start receiving cash gifts
+        </p>
+      </div>
+
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {error && (
+          <p className="text-red-500 text-sm" role="alert">
+            {error}
+          </p>
+        )}
+
+        <Input
+          id="email"
+          label="Email address"
+          type="email"
+          placeholder="john123@gmail.com"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+        />
+
+        <div className="space-y-1">
+          <PasswordInput
+            id="password"
+            label="Password"
+            placeholder="••••••••••••••"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            required
+            autoComplete="current-password"
+          />
+          <div className="flex justify-end">
+            <Link
+              href="/forgot-password"
+              className="text-sm font-medium text-[#6c5ce7] hover:text-[#5f51d8] transition-colors"
+            >
+              Forgot password?
+            </Link>
+          </div>
+        </div>
+
+        <div className="pt-1">
+          <Button
+            type="submit"
+            variant="primary"
+            size="md"
+            className="w-full rounded-lg text-sm font-medium"
+            isLoading={isSubmitting}
+          >
+            Login
+          </Button>
+        </div>
+
+        <p className="text-center text-xs text-[#717182] pt-1">
+          Not registered yet?{" "}
+          <Link
+            href="/auth/sign-up"
+            className="text-[#6c5ce7] hover:text-[#5f51d8] font-medium transition-colors"
+          >
+            Sign Up
+          </Link>
+        </p>
+      </form>
+    </div>
   );
 }
 
 export default function LoginPage() {
   return (
-    <div className="flex flex-col items-center justify-center min-h-screen">
-      <h1 className="text-3xl font-bold mb-6">Login to Zendvo</h1>
+    <AuthLayout showcaseContent={<WorldMapShowcase />}>
       <Suspense fallback={null}>
         <LoginForm />
       </Suspense>
-    </div>
+    </AuthLayout>
   );
 }


### PR DESCRIPTION


## Add Login page with two-panel layout and Forgot password link

### Summary
Implements the Login page to match the design: two-panel layout (form on the left, world map illustration on the right), correct form fields, and a "Forgot password?" link. Reuses the same layout and components as Sign-up and Forgot password.

### Changes
- **Layout:** Login uses `AuthLayout` with `WorldMapShowcase` so the form is centered in the left panel and the illustration fills the right panel.
- **Form:** Email and password inputs with labels ("Email address", "Password") and placeholders (e.g. `john123@gmail.com`), using shared `Input` and `PasswordInput` components.
- **Forgot password:** "Forgot password?" link (right-aligned below the password field) linking to `/forgot-password`.
- **Actions:** Primary "Login" button (with loading state) and "Not registered yet? Sign Up" link to `/auth/sign-up`.
- **Behavior:** Existing login flow unchanged (AuthContext `login()`, callbackUrl redirect, error handling).
- **Responsive:** On mobile the layout stacks vertically and the illustration is hidden (`hidden lg:flex` in AuthLayout).

### Acceptance criteria
- [x] Email and password fields render with correct labels and placeholder text.
- [x] Form is centered vertically in the left panel; illustration fills the right panel.
- [x] Layout is responsive and stacks on mobile with the illustration hidden.
- [x] "Forgot password?" link and Login button are present and styled.

<img width="1349" height="634" alt="image" src="https://github.com/user-attachments/assets/3e615f4a-b50e-4484-9f7d-76816420eb2d" />


### Closes: #36 

---