### PR TITLE
feat: add gift summary endpoint with centralized fee calculation

### DIFF
--- a/__tests__/api/gifts/public-gift-summary.test.ts
+++ b/__tests__/api/gifts/public-gift-summary.test.ts
@@ -1,0 +1,133 @@
+import { GET } from "@/app/api/gifts/public/[giftId]/summary/route";
+import { prisma } from "@/lib/prisma";
+import { NextRequest } from "next/server";
+
+jest.mock("@/lib/prisma", () => ({
+  prisma: {
+    gift: {
+      findUnique: jest.fn(),
+    },
+  },
+}));
+
+describe("GET /api/gifts/public/:giftId/summary", () => {
+  const mockGift = {
+    id: "gift-123",
+    senderId: "sender-123",
+    recipientId: "recipient-123",
+    amount: 10000,
+    currency: "NGN",
+    message: "Happy Birthday!",
+    status: "pending_review",
+    hideAmount: false,
+    hideSender: false,
+    unlockDatetime: new Date("2026-03-01T12:00:00Z"),
+    recipient: {
+      id: "recipient-123",
+      name: "John Doe",
+      email: "john@example.com",
+    },
+    sender: {
+      name: "Jane Smith",
+    },
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("should return 200 with full gift summary", async () => {
+    (prisma.gift.findUnique as jest.Mock).mockResolvedValue(mockGift);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/gifts/public/gift-123/summary",
+    );
+    const params = Promise.resolve({ giftId: "gift-123" });
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.success).toBe(true);
+    expect(data.data).toMatchObject({
+      recipient: {
+        id: "recipient-123",
+        name: "John Doe",
+        email: "john@example.com",
+      },
+      amount: 10000,
+      currency: "NGN",
+      processingFee: 250,
+      totalAmount: 10250,
+      privacySettings: {
+        hideAmount: false,
+        hideSender: false,
+      },
+      unlockDatetime: mockGift.unlockDatetime.toISOString(),
+      message: "Happy Birthday!",
+      senderName: "Jane Smith",
+    });
+  });
+
+  it("should return 404 if gift does not exist", async () => {
+    (prisma.gift.findUnique as jest.Mock).mockResolvedValue(null);
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/gifts/public/gift-123/summary",
+    );
+    const params = Promise.resolve({ giftId: "gift-123" });
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Gift not found");
+  });
+
+  it("should return 400 if gift status is not pending_review", async () => {
+    (prisma.gift.findUnique as jest.Mock).mockResolvedValue({
+      ...mockGift,
+      status: "confirmed",
+    });
+
+    const request = new NextRequest(
+      "http://localhost:3000/api/gifts/public/gift-123/summary",
+    );
+    const params = Promise.resolve({ giftId: "gift-123" });
+
+    const response = await GET(request, { params });
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Gift is not in pending_review status");
+  });
+
+  it("should calculate processing fee correctly for different amounts", async () => {
+    const testCases = [
+      { amount: 1000, expectedFee: 50 }, // Min fee applies
+      { amount: 10000, expectedFee: 250 }, // 2.5%
+      { amount: 100000, expectedFee: 2500 }, // 2.5%
+      { amount: 300000, expectedFee: 5000 }, // Max fee applies
+    ];
+
+    for (const { amount, expectedFee } of testCases) {
+      (prisma.gift.findUnique as jest.Mock).mockResolvedValue({
+        ...mockGift,
+        amount,
+      });
+
+      const request = new NextRequest(
+        "http://localhost:3000/api/gifts/public/gift-123/summary",
+      );
+      const params = Promise.resolve({ giftId: "gift-123" });
+
+      const response = await GET(request, { params });
+      const data = await response.json();
+
+      expect(data.data.processingFee).toBe(expectedFee);
+      expect(data.data.totalAmount).toBe(amount + expectedFee);
+    }
+  });
+});

--- a/__tests__/lib/fees.test.ts
+++ b/__tests__/lib/fees.test.ts
@@ -1,0 +1,63 @@
+import { calculateProcessingFee, FeeConfig } from "@/lib/fees";
+
+describe("calculateProcessingFee", () => {
+  describe("percentage-based fees", () => {
+    const config: FeeConfig = {
+      type: "percentage",
+      value: 2.5,
+      minFee: 50,
+      maxFee: 5000,
+    };
+
+    it("should calculate percentage fee correctly", () => {
+      expect(calculateProcessingFee(10000, config)).toBe(250);
+      expect(calculateProcessingFee(20000, config)).toBe(500);
+      expect(calculateProcessingFee(100000, config)).toBe(2500);
+    });
+
+    it("should apply minimum fee when calculated fee is below minimum", () => {
+      expect(calculateProcessingFee(1000, config)).toBe(50);
+      expect(calculateProcessingFee(500, config)).toBe(50);
+    });
+
+    it("should apply maximum fee when calculated fee exceeds maximum", () => {
+      expect(calculateProcessingFee(300000, config)).toBe(5000);
+      expect(calculateProcessingFee(500000, config)).toBe(5000);
+    });
+  });
+
+  describe("flat fees", () => {
+    const config: FeeConfig = {
+      type: "flat",
+      value: 100,
+    };
+
+    it("should return flat fee regardless of amount", () => {
+      expect(calculateProcessingFee(1000, config)).toBe(100);
+      expect(calculateProcessingFee(10000, config)).toBe(100);
+      expect(calculateProcessingFee(100000, config)).toBe(100);
+    });
+  });
+
+  describe("default configuration", () => {
+    it("should use default config when none provided", () => {
+      expect(calculateProcessingFee(10000)).toBe(250);
+      expect(calculateProcessingFee(1000)).toBe(50);
+      expect(calculateProcessingFee(300000)).toBe(5000);
+    });
+  });
+
+  describe("edge cases", () => {
+    it("should handle zero amount", () => {
+      expect(calculateProcessingFee(0)).toBe(50);
+    });
+
+    it("should round to 2 decimal places", () => {
+      const config: FeeConfig = {
+        type: "percentage",
+        value: 2.75,
+      };
+      expect(calculateProcessingFee(1000, config)).toBe(27.5);
+    });
+  });
+});

--- a/prisma/migrations/20260225185515_add_gift_review_fields/migration.sql
+++ b/prisma/migrations/20260225185515_add_gift_review_fields/migration.sql
@@ -1,0 +1,33 @@
+-- RedefineTables
+PRAGMA defer_foreign_keys=ON;
+PRAGMA foreign_keys=OFF;
+CREATE TABLE "new_Gift" (
+    "id" TEXT NOT NULL PRIMARY KEY,
+    "senderId" TEXT NOT NULL,
+    "recipientId" TEXT NOT NULL,
+    "amount" REAL NOT NULL,
+    "currency" TEXT NOT NULL,
+    "message" TEXT,
+    "template" TEXT,
+    "status" TEXT NOT NULL DEFAULT 'pending_otp',
+    "otpHash" TEXT,
+    "otpExpiresAt" DATETIME,
+    "otpAttempts" INTEGER NOT NULL DEFAULT 0,
+    "transactionId" TEXT,
+    "hideAmount" BOOLEAN NOT NULL DEFAULT false,
+    "hideSender" BOOLEAN NOT NULL DEFAULT false,
+    "unlockDatetime" DATETIME,
+    "createdAt" DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" DATETIME NOT NULL,
+    CONSTRAINT "Gift_senderId_fkey" FOREIGN KEY ("senderId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE,
+    CONSTRAINT "Gift_recipientId_fkey" FOREIGN KEY ("recipientId") REFERENCES "User" ("id") ON DELETE RESTRICT ON UPDATE CASCADE
+);
+INSERT INTO "new_Gift" ("amount", "createdAt", "currency", "id", "message", "otpAttempts", "otpExpiresAt", "otpHash", "recipientId", "senderId", "status", "template", "updatedAt") SELECT "amount", "createdAt", "currency", "id", "message", "otpAttempts", "otpExpiresAt", "otpHash", "recipientId", "senderId", "status", "template", "updatedAt" FROM "Gift";
+DROP TABLE "Gift";
+ALTER TABLE "new_Gift" RENAME TO "Gift";
+CREATE UNIQUE INDEX "Gift_transactionId_key" ON "Gift"("transactionId");
+CREATE INDEX "Gift_senderId_idx" ON "Gift"("senderId");
+CREATE INDEX "Gift_recipientId_idx" ON "Gift"("recipientId");
+CREATE INDEX "Gift_status_idx" ON "Gift"("status");
+PRAGMA foreign_keys=ON;
+PRAGMA defer_foreign_keys=OFF;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -78,6 +78,7 @@ model RefreshToken {
 enum GiftStatus {
   pending_otp
   otp_verified
+  pending_review
   confirmed
   completed
   sent
@@ -85,22 +86,25 @@ enum GiftStatus {
 }
 
 model Gift {
-  id            String     @id @default(uuid())
-  senderId      String
-  sender        User       @relation("SentGifts", fields: [senderId], references: [id])
-  recipientId   String
-  recipient     User       @relation("ReceivedGifts", fields: [recipientId], references: [id])
-  amount        Float
-  currency      String
-  message       String?
-  template      String?
-  status        GiftStatus @default(pending_otp)
-  otpHash       String?
-  otpExpiresAt  DateTime?
-  otpAttempts   Int        @default(0)
-  transactionId String?    @unique
-  createdAt     DateTime   @default(now())
-  updatedAt     DateTime   @updatedAt
+  id             String     @id @default(uuid())
+  senderId       String
+  sender         User       @relation("SentGifts", fields: [senderId], references: [id])
+  recipientId    String
+  recipient      User       @relation("ReceivedGifts", fields: [recipientId], references: [id])
+  amount         Float
+  currency       String
+  message        String?
+  template       String?
+  status         GiftStatus @default(pending_otp)
+  otpHash        String?
+  otpExpiresAt   DateTime?
+  otpAttempts    Int        @default(0)
+  transactionId  String?    @unique
+  hideAmount     Boolean    @default(false)
+  hideSender     Boolean    @default(false)
+  unlockDatetime DateTime?
+  createdAt      DateTime   @default(now())
+  updatedAt      DateTime   @updatedAt
 
   @@index([senderId])
   @@index([recipientId])

--- a/src/app/api/gifts/public/[giftId]/summary/route.ts
+++ b/src/app/api/gifts/public/[giftId]/summary/route.ts
@@ -1,0 +1,78 @@
+import { NextRequest, NextResponse } from "next/server";
+import { prisma } from "@/lib/prisma";
+import { calculateProcessingFee } from "@/lib/fees";
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ giftId: string }> },
+) {
+  try {
+    const { giftId } = await params;
+
+    const gift = await prisma.gift.findUnique({
+      where: { id: giftId },
+      include: {
+        recipient: {
+          select: {
+            id: true,
+            name: true,
+            email: true,
+          },
+        },
+        sender: {
+          select: {
+            name: true,
+          },
+        },
+      },
+    });
+
+    if (!gift) {
+      return NextResponse.json(
+        { success: false, error: "Gift not found" },
+        { status: 404 },
+      );
+    }
+
+    if (gift.status !== "pending_review") {
+      return NextResponse.json(
+        { success: false, error: "Gift is not in pending_review status" },
+        { status: 400 },
+      );
+    }
+
+    const processingFee = calculateProcessingFee(gift.amount);
+    const totalAmount = gift.amount + processingFee;
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          recipient: {
+            id: gift.recipient.id,
+            name: gift.recipient.name,
+            email: gift.recipient.email,
+          },
+          amount: gift.amount,
+          currency: gift.currency,
+          processingFee,
+          totalAmount,
+          privacySettings: {
+            hideAmount: gift.hideAmount,
+            hideSender: gift.hideSender,
+          },
+          unlockDatetime: gift.unlockDatetime,
+          message: gift.message,
+          senderName: gift.sender.name,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Error fetching gift summary:", error);
+    return NextResponse.json(
+      { success: false, error: "Internal server error" },
+      { status: 500 },
+    );
+  }
+}

--- a/src/lib/fees.ts
+++ b/src/lib/fees.ts
@@ -1,0 +1,36 @@
+export interface FeeConfig {
+  type: "flat" | "percentage";
+  value: number;
+  minFee?: number;
+  maxFee?: number;
+}
+
+const DEFAULT_FEE_CONFIG: FeeConfig = {
+  type: "percentage",
+  value: 2.5,
+  minFee: 50,
+  maxFee: 5000,
+};
+
+export function calculateProcessingFee(
+  amount: number,
+  config: FeeConfig = DEFAULT_FEE_CONFIG,
+): number {
+  let fee: number;
+
+  if (config.type === "flat") {
+    fee = config.value;
+  } else {
+    fee = (amount * config.value) / 100;
+  }
+
+  if (config.minFee !== undefined && fee < config.minFee) {
+    fee = config.minFee;
+  }
+
+  if (config.maxFee !== undefined && fee > config.maxFee) {
+    fee = config.maxFee;
+  }
+
+  return Math.round(fee * 100) / 100;
+}


### PR DESCRIPTION
Closes #71
- Create GET /api/gifts/public/:giftId/summary endpoint
- Add centralized fee calculation utility (src/lib/fees.ts)
- Support configurable flat/percentage fees with min/max limits
- Add privacy settings and unlock datetime to Gift model
- Add pending_review status to GiftStatus enum
- Include comprehensive test coverage (11/11 tests passing)