### PR TITLE
fix: add 500 char limit to gift message validation

### DIFF
--- a/src/app/api/gifts/route.ts
+++ b/src/app/api/gifts/route.ts
@@ -6,6 +6,7 @@ import {
   validateAmount,
   validateCurrency,
   sanitizeInput,
+  validateMessage,
 } from "@/lib/validation";
 import { generateOTP, storeGiftOTP } from "@/server/services/otpService";
 import { sendGiftConfirmationOTP } from "@/server/services/emailService";
@@ -82,6 +83,14 @@ export async function POST(request: NextRequest) {
     // Sanitize optional fields
     const sanitizedMessage = message ? sanitizeInput(message) : null;
     const sanitizedTemplate = template ? sanitizeInput(template) : null;
+
+    // Validate message length
+    if (!validateMessage(sanitizedMessage)) {
+      return NextResponse.json(
+        { success: false, error: "Message cannot exceed 500 characters" },
+        { status: 400 },
+      );
+    }
 
     // Create gift record
     const [newGift] = await db

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -60,3 +60,8 @@ export const validateE164PhoneNumber = (phone: string): boolean => {
   // E.164 format: + followed by 7-15 digits
   return /^\+[1-9]\d{6,14}$/.test(sanitized);
 };
+
+export const validateMessage = (message: string | null | undefined): boolean => {
+  if (!message) return true;
+  return message.length <= 500;
+};


### PR DESCRIPTION
Closes #133
Add message validation (max 500 chars) to gift creation API.
- Added validateMessage() to src/lib/validation.ts
- Added 400 response in POST /api/gifts when message exceeds 500 chars
- Validation runs before DB insert to prevent bloat