### PR TITLE
feat(gifts): add isAnonymous flag to hide sender identity from recipi…

### DIFF
--- a/src/app/api/gifts/public/[giftId]/summary/route.ts
+++ b/src/app/api/gifts/public/[giftId]/summary/route.ts
@@ -55,7 +55,7 @@ export async function GET(
           },
           unlockDatetime: gift.unlockDatetime,
           message: gift.message,
-          senderName: gift.sender?.name ?? gift.senderName ?? null,
+          senderName: gift.isAnonymous ? "Anonymous" : (gift.sender?.name ?? gift.senderName ?? null),
         },
       },
       { status: 200 },

--- a/src/server/db/schema.ts
+++ b/src/server/db/schema.ts
@@ -52,6 +52,7 @@ export const gifts = sqliteTable("Gift", {
   transactionId: text("transactionId"),
   hideAmount: integer("hideAmount", { mode: "boolean" }).notNull().default(false),
   hideSender: integer("hideSender", { mode: "boolean" }).notNull().default(false),
+  isAnonymous: integer("isAnonymous", { mode: "boolean" }).notNull().default(false),
   unlockDatetime: text("unlockDatetime"),
   senderName: text("senderName"),
   senderEmail: text("senderEmail"),


### PR DESCRIPTION
What this PR does

Adds an isAnonymous boolean field (default false) to the gifts table, allowing senders to hide their identity from recipients while keeping the real sender data intact in the DB for admin visibility.

Changes

src/server/db/schema.ts — added isAnonymous column to the gifts table

src/app/api/gifts/public/[giftId]/summary/route.ts — senderName resolves to "Anonymous" when isAnonymous is true

Note
The schema already has a hideSender field — worth clarifying if these should be consolidated or serve distinct UI purposes.

Closes #135