### PR TITLE
feat(gifts): add link expiration and cover image selection

### DIFF
--- a/drizzle/0001_add_link_expires_at_to_gifts.sql
+++ b/drizzle/0001_add_link_expires_at_to_gifts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "gifts" ADD COLUMN "link_expires_at" timestamp;

--- a/drizzle/0002_add_cover_image_id_to_gifts.sql
+++ b/drizzle/0002_add_cover_image_id_to_gifts.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "gifts" ADD COLUMN "cover_image_id" text;

--- a/src/app/api/gifts/public/[giftId]/summary/route.ts
+++ b/src/app/api/gifts/public/[giftId]/summary/route.ts
@@ -26,6 +26,13 @@ export async function GET(
       );
     }
 
+    if (gift.linkExpiresAt && new Date(gift.linkExpiresAt) < new Date()) {
+      return NextResponse.json(
+        { success: false, error: "This gift link has expired" },
+        { status: 410 },
+      );
+    }
+
     if (gift.status !== "pending_review") {
       return NextResponse.json(
         { success: false, error: "Gift is not in pending_review status" },

--- a/src/app/api/gifts/route.ts
+++ b/src/app/api/gifts/route.ts
@@ -27,7 +27,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { recipient, amount, currency = "USDC", message, template } = body;
+    const { recipient, amount, currency = "USDC", message, template, coverImageId } = body;
 
     // Validate required fields
     if (!recipient || !amount) {
@@ -82,6 +82,7 @@ export async function POST(request: NextRequest) {
     // Sanitize optional fields
     const sanitizedMessage = message ? sanitizeInput(message) : null;
     const sanitizedTemplate = template ? sanitizeInput(template) : null;
+    const sanitizedCoverImageId = coverImageId ? sanitizeInput(String(coverImageId)) : null;
 
     // Create gift record
     const [newGift] = await db
@@ -93,6 +94,7 @@ export async function POST(request: NextRequest) {
         currency: currency.toUpperCase(),
         message: sanitizedMessage,
         template: sanitizedTemplate,
+        coverImageId: sanitizedCoverImageId,
         status: "pending_otp",
       })
       .returning();

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -142,6 +142,8 @@ export const gifts = pgTable(
     senderAvatar: text("sender_avatar"),
     shareLink: text("share_link").unique(),
     shareLinkToken: text("share_link_token").unique(),
+    coverImageId: text("cover_image_id"),
+    linkExpiresAt: timestamp("link_expires_at"),
     completedAt: timestamp("completed_at"),
     createdAt: timestamp("created_at").defaultNow().notNull(),
     updatedAt: timestamp("updated_at").defaultNow().notNull(),


### PR DESCRIPTION
**Summary**

Gift Link Expiration adds the link_expires_at field to the gifts table. The public gift summary endpoint now returns a 410 Gone status with the message "This gift link has expired" when the field is set and the current time has surpassed it.

- Cover Image ID adds the cover_image_id field to the gifts table. The gift creation endpoint (POST /api/gifts) accepts and stores coverImageId from the request body, allowing the frontend to map it to a local wrap/art catalog.


### Related Issue
<!-- Link the related issue here using 'Closes #XXX' -->
Closes #136 
Close #137 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ √] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update


## Checklist
- [ √] My code follows the [Zendvo Five Principles]
- [ √] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
