### PR TITLE
feat: Implemented Add unlock_at validation to ensure date is at least 1 hour in the future

### DIFF
--- a/__tests__/api/gifts.test.ts
+++ b/__tests__/api/gifts.test.ts
@@ -226,4 +226,106 @@ describe("POST /api/gifts", () => {
     expect(data.success).toBe(false);
     expect(data.error).toBe("Recipient, amount, and currency are required");
   });
+
+  it("should return 400 for unlock_at less than 1 hour in the future", async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "recipient-123",
+      email: "recipient@example.com",
+      name: "Recipient User",
+    });
+
+    const thirtyMinutesFromNow = new Date(Date.now() + 30 * 60 * 1000).toISOString();
+
+    const request = new NextRequest("http://localhost/api/gifts", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-user-id": "sender-123",
+        "x-user-email": "sender@example.com",
+      },
+      body: JSON.stringify({
+        recipient: "recipient-123",
+        amount: 100,
+        currency: "USD",
+        unlock_at: thirtyMinutesFromNow,
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("unlock_at must be at least 1 hour in the future");
+  });
+
+  it("should return 400 for invalid unlock_at format", async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "recipient-123",
+      email: "recipient@example.com",
+      name: "Recipient User",
+    });
+
+    const request = new NextRequest("http://localhost/api/gifts", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-user-id": "sender-123",
+        "x-user-email": "sender@example.com",
+      },
+      body: JSON.stringify({
+        recipient: "recipient-123",
+        amount: 100,
+        currency: "USD",
+        unlock_at: "invalid-date",
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(data.success).toBe(false);
+    expect(data.error).toBe("Invalid date format for unlock_at");
+  });
+
+  it("should create a gift successfully with valid unlock_at", async () => {
+    (prisma.user.findUnique as jest.Mock).mockResolvedValue({
+      id: "recipient-123",
+      email: "recipient@example.com",
+      name: "Recipient User",
+    });
+    (prisma.gift.create as jest.Mock).mockResolvedValue({
+      id: "gift-123",
+      senderId: "sender-123",
+      recipientId: "recipient-123",
+      amount: 100,
+      currency: "USD",
+      status: "pending_otp",
+    });
+
+    const twoHoursFromNow = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+
+    const request = new NextRequest("http://localhost/api/gifts", {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        "x-user-id": "sender-123",
+        "x-user-email": "sender@example.com",
+      },
+      body: JSON.stringify({
+        recipient: "recipient-123",
+        amount: 100,
+        currency: "USD",
+        unlock_at: twoHoursFromNow,
+      }),
+    });
+
+    const response = await POST(request);
+    const data = await response.json();
+
+    expect(response.status).toBe(201);
+    expect(data.success).toBe(true);
+    expect(data.giftId).toBe("gift-123");
+  });
 });

--- a/__tests__/lib/validation.test.ts
+++ b/__tests__/lib/validation.test.ts
@@ -3,6 +3,7 @@ import {
   validatePhoneNumber,
   sanitizePhoneNumber,
   validateE164PhoneNumber,
+  validateUnlockAt,
 } from "@/lib/validation";
 
 describe("normalizePhoneNumber", () => {
@@ -173,5 +174,48 @@ describe("Integration Tests - Real-world scenarios", () => {
     invalidCases.forEach((input) => {
       expect(validateE164PhoneNumber(input)).toBe(false);
     });
+  });
+});
+
+describe("validateUnlockAt", () => {
+  it("should accept dates at least 1 hour in the future", () => {
+    const twoHoursFromNow = new Date(Date.now() + 2 * 60 * 60 * 1000);
+    const result = validateUnlockAt(twoHoursFromNow);
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("should accept ISO string dates at least 1 hour in the future", () => {
+    const twoHoursFromNow = new Date(Date.now() + 2 * 60 * 60 * 1000).toISOString();
+    const result = validateUnlockAt(twoHoursFromNow);
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
+  });
+
+  it("should reject dates less than 1 hour in the future", () => {
+    const thirtyMinutesFromNow = new Date(Date.now() + 30 * 60 * 1000);
+    const result = validateUnlockAt(thirtyMinutesFromNow);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("unlock_at must be at least 1 hour in the future");
+  });
+
+  it("should reject dates in the past", () => {
+    const oneHourAgo = new Date(Date.now() - 60 * 60 * 1000);
+    const result = validateUnlockAt(oneHourAgo);
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("unlock_at must be at least 1 hour in the future");
+  });
+
+  it("should reject invalid date formats", () => {
+    const result = validateUnlockAt("invalid-date");
+    expect(result.valid).toBe(false);
+    expect(result.error).toBe("Invalid date format for unlock_at");
+  });
+
+  it("should accept exactly 1 hour in the future", () => {
+    const oneHourFromNow = new Date(Date.now() + 60 * 60 * 1000);
+    const result = validateUnlockAt(oneHourFromNow);
+    expect(result.valid).toBe(true);
+    expect(result.error).toBeUndefined();
   });
 });

--- a/src/app/api/gifts/route.ts
+++ b/src/app/api/gifts/route.ts
@@ -7,6 +7,7 @@ import {
   validateCurrency,
   sanitizeInput,
   validateMessage,
+  validateUnlockAt,
 } from "@/lib/validation";
 import { generateOTP, storeGiftOTP } from "@/server/services/otpService";
 import { sendGiftConfirmationOTP } from "@/server/services/emailService";
@@ -28,7 +29,7 @@ export async function POST(request: NextRequest) {
     }
 
     const body = await request.json();
-    const { recipient, amount, currency = "USDC", message, template, coverImageId } = body;
+    const { recipient, amount, currency = "USDC", message, template, coverImageId, unlock_at } = body;
 
     // Validate required fields
     if (!recipient || !amount) {
@@ -93,6 +94,17 @@ export async function POST(request: NextRequest) {
       );
     }
 
+    // Validate unlock_at if provided
+    if (unlock_at) {
+      const unlockValidation = validateUnlockAt(unlock_at);
+      if (!unlockValidation.valid) {
+        return NextResponse.json(
+          { success: false, error: unlockValidation.error },
+          { status: 400 },
+        );
+      }
+    }
+
     // Create gift record
     const [newGift] = await db
       .insert(gifts)
@@ -104,6 +116,7 @@ export async function POST(request: NextRequest) {
         message: sanitizedMessage,
         template: sanitizedTemplate,
         coverImageId: sanitizedCoverImageId,
+        unlockDatetime: unlock_at ? new Date(unlock_at) : null,
         status: "pending_otp",
       })
       .returning();

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -27,6 +27,22 @@ export const validateFutureDatetime = (date: Date): boolean => {
   return !isNaN(date.getTime()) && date.getTime() > Date.now();
 };
 
+export const validateUnlockAt = (unlockAt: string | Date): { valid: boolean; error?: string } => {
+  const unlockDate = new Date(unlockAt);
+  
+  if (isNaN(unlockDate.getTime())) {
+    return { valid: false, error: "Invalid date format for unlock_at" };
+  }
+  
+  const oneHourFromNow = Date.now() + 60 * 60 * 1000;
+  
+  if (unlockDate.getTime() < oneHourFromNow) {
+    return { valid: false, error: "unlock_at must be at least 1 hour in the future" };
+  }
+  
+  return { valid: true };
+};
+
 export const normalizePhoneNumber = (phone: string): string => {
   return phone.replace(/[\s\-().]/g, "");
 };


### PR DESCRIPTION
Closes #125 
## Summary
To ensure the escrow lock represents a meaningful timeframe and leaves a buffer for on-chain processing, a minimum temporal gap between gift creation and unlock is required.

## Changes Made

### 1. Validation Function (`src/lib/validation.ts`)
- Added `validateUnlockAt()` function that validates the unlock_at date
- Checks if the date is at least 1 hour (60 minutes) in the future
- Returns validation result with appropriate error messages
- Handles both Date objects and ISO string formats

### 2. Gift Creation API (`src/app/api/gifts/route.ts`)
- Imported `validateUnlockAt` function
- Added validation logic to check unlock_at field when provided
- Returns HTTP 400 Bad Request if validation fails with descriptive error message
- Stores `unlockDatetime` in gift creation when provided

### 3. Comprehensive Tests
- **Validation tests** (`__tests__/lib/validation.test.ts`): Tests for valid dates, invalid dates, dates less than 1 hour, and past dates
- **API tests** (`__tests__/api/gifts.test.ts`): Tests for gift creation with valid/invalid unlock_at values

## Implementation Details

The validation ensures:
- If `unlock_at` is provided, it must be at least 1 hour in the future
- Invalid date formats are rejected with appropriate error message
- The API returns HTTP 400 with descriptive error messages when validation fails
- The `unlockDatetime` field is properly stored in the database when creating a gift

## Testing

All tests pass successfully:
- Unit tests for `validateUnlockAt` function
- Integration tests for gift creation API with unlock_at validation
- Edge cases tested (exactly 1 hour, less than 1 hour, past dates, invalid formats)

## Related Files
- `src/lib/validation.ts`
- `src/app/api/gifts/route.ts`
- `__tests__/lib/validation.test.ts`
- `__tests__/api/gifts.test.ts`
