### PR TITLE
feat: expose phone_last_4 in auth/me response to reduce PII leakage

### DIFF
--- a/__tests__/api/auth/me.test.ts
+++ b/__tests__/api/auth/me.test.ts
@@ -1,0 +1,115 @@
+import { NextRequest } from "next/server";
+import { db } from "@/lib/db";
+import { getAuthPayload } from "@/lib/auth-session";
+
+jest.mock("drizzle-orm", () => ({
+  eq: jest.fn(() => ({})),
+}));
+
+jest.mock("@/lib/db", () => ({
+  db: {
+    query: {
+      users: {
+        findFirst: jest.fn(),
+      },
+    },
+  },
+}));
+
+jest.mock("@/lib/db/schema", () => ({
+  users: {
+    id: "id",
+  },
+}));
+
+jest.mock("@/lib/auth-session", () => ({
+  getAuthPayload: jest.fn(),
+}));
+
+describe("GET /api/auth/me", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const makeRequest = () =>
+    new NextRequest("http://localhost/api/auth/me", {
+      method: "GET",
+    });
+
+  it("returns unauthorized when no auth payload is present", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue(null);
+    const { GET } = await import("@/app/api/auth/me/route");
+
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.success).toBe(false);
+    expect(json.error).toBe("Unauthorized");
+  });
+
+  it("returns phone_last_4 and never includes phone fields", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "user-1" });
+    (db.query.users.findFirst as jest.Mock).mockResolvedValue({
+      id: "user-1",
+      email: "user@example.com",
+      name: "Test User",
+      phoneNumber: "+2348012345678",
+      role: "user",
+      status: "active",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      lastLogin: new Date("2026-01-02T00:00:00.000Z"),
+    });
+    const { GET } = await import("@/app/api/auth/me/route");
+
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.user.phone_last_4).toBe("5678");
+    expect(json.user.phone).toBeUndefined();
+    expect(json.user.phoneNumber).toBeUndefined();
+  });
+
+  it("returns null phone_last_4 when user has no phone", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "user-2" });
+    (db.query.users.findFirst as jest.Mock).mockResolvedValue({
+      id: "user-2",
+      email: "nophone@example.com",
+      name: "No Phone",
+      phoneNumber: null,
+      role: "user",
+      status: "unverified",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      lastLogin: null,
+    });
+    const { GET } = await import("@/app/api/auth/me/route");
+
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.user.phone_last_4).toBeNull();
+  });
+
+  it("returns available characters when phone has fewer than 4", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "user-3" });
+    (db.query.users.findFirst as jest.Mock).mockResolvedValue({
+      id: "user-3",
+      email: "short@example.com",
+      name: "Short Phone",
+      phoneNumber: "123",
+      role: "user",
+      status: "active",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      lastLogin: null,
+    });
+    const { GET } = await import("@/app/api/auth/me/route");
+
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.user.phone_last_4).toBe("123");
+  });
+});

--- a/src/app/api/auth/me/route.ts
+++ b/src/app/api/auth/me/route.ts
@@ -4,6 +4,18 @@ import { users } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
 import { getAuthPayload } from "@/lib/auth-session";
 
+type AuthMeUser = {
+  id: string;
+  email: string;
+  name: string | null;
+  role: string;
+  status: string;
+  createdAt: Date;
+  lastLogin: Date | null;
+  email_verified: boolean;
+  phone_last_4: string | null;
+};
+
 export async function GET(request: NextRequest) {
   try {
     const payload = await getAuthPayload(request);
@@ -20,6 +32,7 @@ export async function GET(request: NextRequest) {
         id: true,
         email: true,
         name: true,
+        phoneNumber: true,
         role: true,
         status: true,
         createdAt: true,
@@ -34,13 +47,22 @@ export async function GET(request: NextRequest) {
       );
     }
 
+    const responseUser: AuthMeUser = {
+      id: user.id,
+      email: user.email,
+      name: user.name,
+      role: user.role,
+      status: user.status,
+      createdAt: user.createdAt,
+      lastLogin: user.lastLogin,
+      email_verified: user.status === "active",
+      phone_last_4: user.phoneNumber?.slice(-4) ?? null,
+    };
+
     return NextResponse.json(
       {
         success: true,
-        user: {
-          ...user,
-          email_verified: user.status === "active",
-        },
+        user: responseUser,
       },
       { status: 200 },
     );


### PR DESCRIPTION
Closes #122

## Summary
Implements PII protection for phone numbers in the `/api/auth/me` endpoint
using the dynamic API approach (Option A) — no schema migration required.
The endpoint now computes and returns only `phone_last_4` and never serializes
the full `phoneNumber` to the frontend. An explicit typed DTO (`AuthMeUser`)
replaces the previous spread-based return, making it impossible for new fields
to leak accidentally.

## What changed

### `src/app/api/auth/me/route.ts` *(modified)*
- `phoneNumber` is fetched from DB for server-side derivation only
- `phone_last_4` computed as `user.phoneNumber?.slice(-4) ?? null`
- Explicit `AuthMeUser` DTO introduced — only safe fields are serialized
- Full `phone` / `phoneNumber` values are not present in the response
- Null phone handled gracefully (`phone_last_4: null`)
- Short phone edge case handled: returns whatever digits exist (no error)

### `__tests__/api/auth/me.test.ts` *(new)*
- Unauthorized request returns 401
- Response includes `phone_last_4` and excludes `phone` and `phoneNumber`
- `phone_last_4` is `null` when user has no phone set
- Short phone edge case (`"123"`) returns `"123"`

## Survey findings
- ORM: Drizzle + Postgres; schema in `src/lib/db/schema.ts`
- `users` table already has `phoneNumber`; no `phone_last_4` existed in schema
- No frontend consumers were found reading `phone` from `/api/auth/me` —
  no frontend changes required
- No shared DTO existed for this endpoint before this PR; explicit typing
  now introduced in the route

## Verification
npm test -- tests/api/auth/me.test.ts  ✅  4/4 passed

## Notes
- Pre-existing unrelated test failures exist in `__tests__/api/auth/login.test.ts`,
  `__tests__/api/gifts.test.ts`, and `__tests__/api/auth/token-flow.test.ts` —
  not introduced by this PR
- Pre-existing TypeScript error in
  `src/app/api/gifts/public/[giftId]/summary/route.ts` (`gift.isAnonymous`
  missing on inferred type) causes `npm run build` to fail — not introduced
  by this PR. All files touched for #122 are type-clean
- If a schema-backed variant is preferred (`phone_last_4` persisted in DB
  with migration + write paths), that can be implemented as a follow-up
- The `AuthMeUser` DTO could be moved to a shared `types` module and wired
  into the client-side fetch layer for stronger compile-time guarantees —
  available as a follow-up if desired