### PR TITLE
fix: ensure 44x44px minimum touch target for interactive elements

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -41,3 +41,22 @@
   display: inline-block;
   animation: slide-down 0.35s cubic-bezier(0.175, 0.885, 0.32, 1.275) forwards;
 }
+
+/* Minimum touch target size (44x44px) for WCAG 2.5.8 compliance */
+button,
+a,
+input[type="checkbox"],
+input[type="radio"],
+[role="button"],
+[role="link"],
+[role="tab"],
+[role="menuitem"] {
+  min-height: 44px;
+  min-width: 44px;
+}
+
+/* Icon-only buttons: ensure hit area via padding */
+button:has(svg:only-child),
+a:has(svg:only-child) {
+  padding: 10px;
+}


### PR DESCRIPTION
## Summary
Add global CSS rules enforcing WCAG 2.5.8 minimum 44x44px touch target size for all interactive elements.

## Changes
Added to `src/app/globals.css`:
- `min-height: 44px; min-width: 44px` for `button`, `a`, checkboxes, radios, and ARIA role elements
- Extra padding for icon-only buttons (`button:has(svg:only-child)`)

## Test plan
- [ ] Inspect buttons on mobile viewport — all ≥ 44x44px
- [ ] Verify checkboxes and radio buttons meet minimum size
- [ ] Verify icon-only buttons have adequate hit area
- [ ] No visual regression on desktop

Closes #177