### PR TITLE
feat(webhooks): add secure Paystack webhook handler with idempotent g…

### DIFF
--- a/src/app/api/webhooks/paystack/route.ts
+++ b/src/app/api/webhooks/paystack/route.ts
@@ -1,9 +1,10 @@
 import crypto from "crypto";
 import { NextRequest, NextResponse } from "next/server";
+import { markGiftPaymentSuccessfulByReference } from "@/server/services/giftStatusService";
 
 /**
  * Paystack Webhook Handler
- * 
+ *
  * This endpoint receives events from Paystack.
  * It cryptographically verifies the x-paystack-signature header
  * to ensure the request is authentic.
@@ -13,24 +14,13 @@ export async function POST(req: NextRequest) {
     const signature = req.headers.get("x-paystack-signature");
     const secret = process.env.PAYSTACK_SECRET_KEY;
 
-    if (!secret) {
-      console.error("[PAYSTACK_WEBHOOK] PAYSTACK_SECRET_KEY is not configured");
-      return NextResponse.json(
-        { error: "Webhook secret not configured" },
-        { status: 500 }
-      );
-    }
-
-    if (!signature) {
-      console.warn("[PAYSTACK_WEBHOOK] Missing x-paystack-signature header");
-      return NextResponse.json(
-        { error: "Missing signature" },
-        { status: 401 }
-      );
-    }
-
     // Read the raw request body as text for verification
     const rawBody = await req.text();
+
+    if (!secret || !signature) {
+      console.warn("[PAYSTACK_WEBHOOK] Invalid signature context");
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
 
     // Compute HMAC SHA512 hash of the raw body using the secret key
     const hash = crypto
@@ -38,13 +28,21 @@ export async function POST(req: NextRequest) {
       .update(rawBody)
       .digest("hex");
 
+    if (hash.length !== signature.length) {
+      console.warn("[PAYSTACK_WEBHOOK] Invalid signature length");
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
+    }
+
     // Verify that the computed hash matches the signature from Paystack
-    if (hash !== signature) {
+    const computed = Buffer.from(hash, "hex");
+    const received = Buffer.from(signature, "hex");
+
+    if (
+      computed.length !== received.length ||
+      !crypto.timingSafeEqual(computed, received)
+    ) {
       console.warn("[PAYSTACK_WEBHOOK] Invalid signature detected");
-      return NextResponse.json(
-        { error: "Invalid signature" },
-        { status: 401 }
-      );
+      return NextResponse.json({ error: "Invalid signature" }, { status: 401 });
     }
 
     // Parse the validated payload
@@ -52,27 +50,31 @@ export async function POST(req: NextRequest) {
 
     console.log(`[PAYSTACK_WEBHOOK] Received event: ${event.event}`);
 
-    /**
-     * Handle Paystack events here.
-     * Common events:
-     * - charge.success: Payment was successful
-     * - transfer.success: Payout was successful
-     * - transfer.failed: Payout failed
-     */
-    
-    // TODO: Implement specific event handling logic
-    // Example:
-    // if (event.event === 'charge.success') {
-    //   const { reference, metadata } = event.data;
-    //   // Update gift status in database
-    // }
+    if (event?.event !== "charge.success") {
+      return NextResponse.json({ received: true }, { status: 200 });
+    }
+
+    const reference = event?.data?.reference;
+
+    if (!reference || typeof reference !== "string") {
+      console.warn("[PAYSTACK_WEBHOOK] charge.success missing reference");
+      return NextResponse.json({ received: true }, { status: 200 });
+    }
+
+    const result = await markGiftPaymentSuccessfulByReference(
+      reference,
+      "paystack",
+    );
+
+    if (!result.success) {
+      console.warn(
+        `[PAYSTACK_WEBHOOK] Unable to process reference ${reference}: ${result.message}`,
+      );
+    }
 
     return NextResponse.json({ received: true }, { status: 200 });
   } catch (error) {
     console.error("[PAYSTACK_WEBHOOK_ERROR]", error);
-    return NextResponse.json(
-      { error: "Internal server error" },
-      { status: 500 }
-    );
+    return NextResponse.json({ received: true }, { status: 200 });
   }
 }

--- a/src/server/services/giftStatusService.ts
+++ b/src/server/services/giftStatusService.ts
@@ -24,7 +24,7 @@ export interface StatusTransitionResult {
 export async function validateGiftStatusTransition(
   giftId: string,
   targetStatus: GiftStatus,
-  currentUserId?: string
+  currentUserId?: string,
 ): Promise<StatusTransitionResult> {
   const gift = await db.query.gifts.findFirst({
     where: eq(gifts.id, giftId),
@@ -38,11 +38,11 @@ export async function validateGiftStatusTransition(
   }
 
   const currentStatus = gift.status as GiftStatus;
-  
+
   // Check if transition is allowed
   const allowedTransitions: readonly GiftStatus[] =
     GIFT_STATUS_TRANSITIONS[currentStatus] || [];
-  
+
   if (!allowedTransitions.includes(targetStatus)) {
     return {
       success: false,
@@ -53,7 +53,11 @@ export async function validateGiftStatusTransition(
   }
 
   // Additional business logic validations
-  const validationResult = await validateBusinessRules(gift, targetStatus, currentUserId);
+  const validationResult = await validateBusinessRules(
+    gift,
+    targetStatus,
+    currentUserId,
+  );
   if (!validationResult.success) {
     return validationResult;
   }
@@ -69,14 +73,18 @@ export async function validateGiftStatusTransition(
 async function validateBusinessRules(
   gift: any,
   targetStatus: GiftStatus,
-  currentUserId?: string
+  currentUserId?: string,
 ): Promise<StatusTransitionResult> {
   const now = new Date();
 
   switch (targetStatus) {
     case "otp_verified":
       // Can only fund if OTP is verified (for sender-initiated gifts)
-      if (gift.otpHash && gift.otpExpiresAt && now > new Date(gift.otpExpiresAt)) {
+      if (
+        gift.otpHash &&
+        gift.otpExpiresAt &&
+        now > new Date(gift.otpExpiresAt)
+      ) {
         return {
           success: false,
           message: "OTP has expired. Please request a new verification code.",
@@ -92,7 +100,7 @@ async function validateBusinessRules(
           message: "Cannot lock gift: no unlock datetime specified",
         };
       }
-      
+
       if (new Date(gift.unlockDatetime) <= now) {
         return {
           success: false,
@@ -106,7 +114,8 @@ async function validateBusinessRules(
       if (gift.unlockDatetime && new Date(gift.unlockDatetime) > now) {
         return {
           success: false,
-          message: "Gift cannot be unlocked yet. Please wait until the unlock datetime.",
+          message:
+            "Gift cannot be unlocked yet. Please wait until the unlock datetime.",
         };
       }
       break;
@@ -135,36 +144,96 @@ async function validateBusinessRules(
 export async function transitionGiftStatus(
   giftId: string,
   targetStatus: GiftStatus,
-  metadata?: Record<string, any>
+  metadata?: Record<string, any>,
 ): Promise<StatusTransitionResult> {
   const validation = await validateGiftStatusTransition(giftId, targetStatus);
-  
+
   if (!validation.success) {
     return validation;
   }
 
   try {
     const updateData: any = { status: targetStatus };
-    
+
     // Add metadata for specific transitions
-    if ((targetStatus === "completed" || targetStatus === "sent") && metadata?.transactionId) {
+    if (
+      (targetStatus === "completed" || targetStatus === "sent") &&
+      metadata?.transactionId
+    ) {
       updateData.transactionId = metadata.transactionId;
     }
 
-    await db
-      .update(gifts)
-      .set(updateData)
-      .where(eq(gifts.id, giftId));
+    await db.update(gifts).set(updateData).where(eq(gifts.id, giftId));
 
     return {
       success: true,
       message: `Gift status successfully updated to ${targetStatus}`,
     };
   } catch (error) {
-    console.error(`Error transitioning gift ${giftId} to ${targetStatus}:`, error);
+    console.error(
+      `Error transitioning gift ${giftId} to ${targetStatus}:`,
+      error,
+    );
     return {
       success: false,
       message: "Database error while updating gift status",
+    };
+  }
+}
+
+export async function markGiftPaymentSuccessfulByReference(
+  reference: string,
+  provider: "paystack" | "stripe",
+): Promise<StatusTransitionResult> {
+  try {
+    const gift = await db.query.gifts.findFirst({
+      where: and(
+        eq(gifts.paymentReference, reference),
+        eq(gifts.paymentProvider, provider),
+      ),
+    });
+
+    if (!gift) {
+      return {
+        success: false,
+        message: "Gift not found for payment reference",
+      };
+    }
+
+    const alreadyProcessedStatuses = [
+      "pending_review",
+      "confirmed",
+      "completed",
+      "sent",
+    ];
+
+    if (alreadyProcessedStatuses.includes(gift.status as string)) {
+      return {
+        success: true,
+        message: `Gift already processed with status ${gift.status}`,
+        currentStatus: gift.status,
+      };
+    }
+
+    await db
+      .update(gifts)
+      .set({
+        status: "pending_review",
+        paymentVerifiedAt: new Date(),
+        updatedAt: new Date(),
+      })
+      .where(eq(gifts.id, gift.id));
+
+    return {
+      success: true,
+      message: "Gift payment marked successful",
+      currentStatus: "pending_review",
+    };
+  } catch (error) {
+    console.error("Error marking gift payment successful by reference:", error);
+    return {
+      success: false,
+      message: "Database error while marking payment successful",
     };
   }
 }
@@ -185,7 +254,10 @@ export function isTerminalStatus(status: GiftStatus): boolean {
   return status === "sent" || status === "failed";
 }
 
-export function canTransitionFrom(currentStatus: GiftStatus, targetStatus: GiftStatus): boolean {
+export function canTransitionFrom(
+  currentStatus: GiftStatus,
+  targetStatus: GiftStatus,
+): boolean {
   const transitions: readonly GiftStatus[] =
     GIFT_STATUS_TRANSITIONS[currentStatus] || [];
   return transitions.includes(targetStatus);


### PR DESCRIPTION
## Summary
Implements a secure Paystack webhook handler to process asynchronous payment confirmations and automatically advance gift status.

The webhook verifies request authenticity using HMAC-SHA512, processes only `charge.success` events, and updates the corresponding gift to `pending_review` using a provider-scoped payment reference. The implementation is idempotent and safely handles duplicate webhook deliveries.

### Related Issue
Closes #163

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

- Manually simulated Paystack webhook payloads with valid and invalid signatures
- Verified signature validation using raw request body and HMAC-SHA512
- Tested `charge.success` event handling:
  - Valid reference updates gift to `pending_review`
  - Missing/invalid reference is safely ignored
- Verified idempotency:
  - Repeated webhook calls do not reprocess already updated gifts
- Confirmed non-relevant events are ignored with 200 response
- Ensured invalid signatures return 401

### Screenshots / Videos
N/A

## Checklist
- [x] My code follows the [Zendvo Five Principles]
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes