### PR TITLE
feat(security): implement admin alert for suspicious OTP activity #121

### DIFF
--- a/src/server/services/emailService.ts
+++ b/src/server/services/emailService.ts
@@ -12,6 +12,53 @@ const EMAIL_CONFIG = {
 
 const transporter = nodemailer.createTransport(EMAIL_CONFIG);
 
+export async function sendAdminAlert(data: {
+  userIds: string[];
+  ips: string[];
+  phoneNumbers: string[];
+  failureCount: number;
+}) {
+  const adminEmail = process.env.ADMIN_EMAIL || EMAIL_CONFIG.auth.user;
+  const mailOptions = {
+    from: `"Zendvo Security" <${EMAIL_CONFIG.auth.user}>`,
+    to: adminEmail,
+    subject: "🚨 SECURITY ALERT: Suspicious OTP Brute-force Detected",
+    html: generateAdminAlertTemplate(data),
+    text: `Suspicious Activity Alert!\n\nThreshold: ${data.failureCount} failed OTP attempts.\nIPs: ${data.ips.join(", ")}\nUser IDs: ${data.userIds.join(", ")}\nPhone Numbers: ${data.phoneNumbers.join(", ")}`,
+  };
+
+  try {
+    if (process.env.NODE_ENV === "development") {
+      console.log("!".repeat(50));
+      console.log("🚨 ADMIN SECURITY ALERT (Development Mode)");
+      console.log("!".repeat(50));
+      console.log(`To Admin: ${adminEmail}`);
+      console.log(`Failures: ${data.failureCount}`);
+      console.log(`Involved IPs: ${data.ips.join(", ")}`);
+      console.log("!".repeat(50));
+      return {
+        success: true,
+        messageId: "dev-mode",
+        message: "Admin alert logged to console",
+      };
+    }
+
+    const info = await transporter.sendMail(mailOptions);
+    return {
+      success: true,
+      messageId: info.messageId,
+      message: "Admin security alert sent successfully",
+    };
+  } catch (error) {
+    console.error("Error sending admin security alert:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+      message: "Failed to send admin security alert",
+    };
+  }
+}
+
 export async function sendVerificationEmail(
   email: string,
   otp: string,
@@ -304,6 +351,50 @@ function generateSecurityAlertTemplate(userName?: string): string {
           </td>
         </tr>
       </table>
+    `,
+  });
+}
+
+function generateAdminAlertTemplate(data: {
+  userIds: string[];
+  ips: string[];
+  phoneNumbers: string[];
+  failureCount: number;
+}): string {
+  return generateBaseTemplate({
+    title: "Suspicious Activity Detected",
+    userName: "Administrator",
+    content: `
+      <div style="background-color: #fff5f5; border-left: 4px solid #c53030; padding: 20px; margin: 0 0 30px 0;">
+        <h3 style="margin: 0 0 10px; color: #c53030; font-size: 18px;">Brute-force Threshold Reached</h3>
+        <p style="margin: 0; color: #742a2a; font-size: 14px;">
+          Our security system has detected <strong>${data.failureCount}</strong> consecutive OTP verification failures from a single source.
+        </p>
+      </div>
+
+      <h4 style="color: #2d3748; margin: 20px 0 10px;">Security Metadata:</h4>
+      <table width="100%" cellpadding="10" cellspacing="0" style="border: 1px solid #e2e8f0; border-radius: 8px; font-size: 14px; color: #4a5568;">
+        <tr style="background-color: #f7fafc;">
+          <td width="30%"><strong>Involved IPs</strong></td>
+          <td style="word-break: break-all; font-family: monospace;">${data.ips.join(", ") || "Unknown"}</td>
+        </tr>
+        <tr>
+          <td><strong>Targeted User IDs</strong></td>
+          <td style="word-break: break-all; font-family: monospace;">${data.userIds.join(", ") || "None"}</td>
+        </tr>
+        <tr style="background-color: #f7fafc;">
+          <td><strong>Phone Numbers</strong></td>
+          <td>${data.phoneNumbers.join(", ") || "None"}</td>
+        </tr>
+        <tr>
+          <td><strong>Timestamp</strong></td>
+          <td>${new Date().toISOString()}</td>
+        </tr>
+      </table>
+
+      <p style="margin: 30px 0 0; color: #4a5568; font-size: 14px; line-height: 1.6;">
+        <strong>Recommended Action:</strong> Please investigate the involved IP addresses and consider temporary blacklisting if the activity persists across different accounts.
+      </p>
     `,
   });
 }

--- a/src/server/services/otpService.ts
+++ b/src/server/services/otpService.ts
@@ -9,6 +9,19 @@ import {
   logGiftOTPEvent,
   logOTPEvent,
 } from "@/server/services/auditService";
+import { sendAdminAlert } from "./emailService";
+
+const SUSPICIOUS_OTP_THRESHOLD = 20;
+const IP_TRACKING_WINDOW_MS = 60 * 60 * 1000; // 1 hour rolling window
+
+type IpFailureState = {
+  count: number;
+  userIds: Set<string>;
+  phoneNumbers: Set<string>;
+  lastAttempt: number;
+};
+
+const otpFailuresByIp = new Map<string, IpFailureState>();
 
 export const MAX_OTP_REQUESTS_PER_PHONE = 4;
 export const OTP_RATE_LIMIT_WINDOW_MS = 10 * 60 * 1000;
@@ -283,7 +296,7 @@ export async function storeOTP(userId: string, otp: string) {
   return newVerification;
 }
 
-export async function verifyOTP(userId: string, otp: string) {
+export async function verifyOTP(userId: string, otp: string, ipAddress?: string) {
   const verification = await db.query.emailVerifications.findFirst({
     where: and(
       eq(emailVerifications.userId, userId),
@@ -365,6 +378,43 @@ export async function verifyOTP(userId: string, otp: string) {
         otpAttemptsWindowStart: windowStart,
       })
       .where(eq(users.id, userId));
+
+    // IP-based suspicious activity tracking
+    if (ipAddress) {
+      const now = Date.now();
+      let state = otpFailuresByIp.get(ipAddress);
+
+      // Reset tracking state if window has expired since last attempt
+      if (state && now - state.lastAttempt > IP_TRACKING_WINDOW_MS) {
+        otpFailuresByIp.delete(ipAddress);
+        state = undefined;
+      }
+
+      if (!state) {
+        state = {
+          count: 0,
+          userIds: new Set<string>(),
+          phoneNumbers: new Set<string>(),
+          lastAttempt: now,
+        };
+      }
+
+      state.count++;
+      state.lastAttempt = now;
+      state.userIds.add(userId);
+      if (user?.phoneNumber) state.phoneNumbers.add(user.phoneNumber);
+
+      otpFailuresByIp.set(ipAddress, state);
+
+      if (state.count === SUSPICIOUS_OTP_THRESHOLD) {
+        sendAdminAlert({
+          userIds: Array.from(state.userIds),
+          ips: [ipAddress],
+          phoneNumbers: Array.from(state.phoneNumbers),
+          failureCount: state.count,
+        }).catch((err) => console.error("[ADMIN_ALERT_ERROR]", err));
+      }
+    }
 
     logOTPEvent(AuditEventType.OTP_VERIFIED_FAILED, userId, {
       attemptNumber: newAttempts,


### PR DESCRIPTION
### 📝 Problem & Impact
Brute-force OTP attempts are a high-signal indicator of systemic attacks against user accounts. Previously, while we had user-level locking, there was no mechanism to alert administrators of high-frequency failures originating from a single IP address targeting multiple accounts.

This implementation allows operations to identify and mitigate distributed brute-force attacks by providing immediate visibility into suspicious metadata.

### 🛠️ Proposed Changes
- **otpService.ts**: 
    - Implemented a rolling 1-hour window for IP-based failure tracking using `otpFailuresByIp`.
    - Integrated a trigger to call `sendAdminAlert` exactly at the 20th failure threshold.
    - Aggregated metadata including unique User IDs and Phone Numbers targeted by the source IP.
- **emailService.ts**: 
    - Added `sendAdminAlert` function to handle high-priority security notifications.
    - Created a specialized HTML email template with a metadata table for rapid investigation.
    - Added development mode logging to verify triggers without SMTP overhead.

### ✅ Done Verification Checklist
- [x] **Problem & Impact**: Clearly stated above.
- [x] **Issue Linked**: Closes #121
- [x] **Tests**: Verified via `__tests__/otpService.security.test.ts` and manual `scripts/test-otp-security.ts`.
- [x] **Code Quality**: Follows Zendvo principles; utilizes existing audit logging and service patterns.

### 🧪 How to Test
1. Set `NODE_ENV=development` in your `.env`.
2. Use a tool like Postman to trigger 20 failed OTP verification calls from the same IP.
3. Observe the console output for the `🚨 ADMIN SECURITY ALERT` block.
4. Verify that the unique User IDs and Phone Numbers targeted during the window are correctly listed in the alert data.

Closes #121
