### PR TITLE
fix: color contrast on secondary Disabled buttons

### DIFF
--- a/__tests__/button-contrast.test.ts
+++ b/__tests__/button-contrast.test.ts
@@ -1,0 +1,55 @@
+import {
+  secondaryDisabledBg,
+  secondaryDisabledText,
+} from "../src/components/buttonColors";
+
+// helpers
+function hexToRgb(hex: string) {
+  // Support #RRGGBB and #RGB
+  const h = hex.replace("#", "");
+  if (h.length === 3) {
+    return [
+      parseInt(h[0] + h[0], 16),
+      parseInt(h[1] + h[1], 16),
+      parseInt(h[2] + h[2], 16),
+    ];
+  }
+  if (h.length === 6) {
+    return [
+      parseInt(h.slice(0, 2), 16),
+      parseInt(h.slice(2, 4), 16),
+      parseInt(h.slice(4, 6), 16),
+    ];
+  }
+  // Fallback
+  throw new Error(`Unsupported hex color: ${hex}`);
+}
+
+function srgbToLinear(v: number) {
+  const s = v / 255;
+  return s <= 0.03928 ? s / 12.92 : Math.pow((s + 0.055) / 1.055, 2.4);
+}
+
+function relativeLuminance(hex: string) {
+  const [r, g, b] = hexToRgb(hex);
+  const R = srgbToLinear(r);
+  const G = srgbToLinear(g);
+  const B = srgbToLinear(b);
+  return 0.2126 * R + 0.7152 * G + 0.0722 * B;
+}
+
+function contrastRatio(hex1: string, hex2: string) {
+  const L1 = relativeLuminance(hex1);
+  const L2 = relativeLuminance(hex2);
+  const lighter = Math.max(L1, L2);
+  const darker = Math.min(L1, L2);
+  return +((lighter + 0.05) / (darker + 0.05)).toFixed(2);
+}
+
+describe("Button disabled color contrast", () => {
+  test("secondary disabled text/background meet >= 3:1 WCAG AA legibility", () => {
+    const ratio = contrastRatio(secondaryDisabledText, secondaryDisabledBg);
+    console.log("Contrast ratio (secondary disabled):", ratio);
+    expect(ratio).toBeGreaterThanOrEqual(3);
+  });
+});

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import React from "react";
+import { secondaryDisabledBg, secondaryDisabledText } from "./buttonColors";
 
 interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
   variant?: "primary" | "secondary" | "outline";
@@ -18,12 +19,13 @@ const Button: React.FC<ButtonProps> = ({
   ...props
 }) => {
   const baseStyles =
-    "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:opacity-50";
+    "inline-flex items-center justify-center rounded-md font-medium transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:pointer-events-none disabled:cursor-not-allowed";
 
   const variants = {
     primary:
       "bg-[#5A45FE] text-white hover:bg-[#4b35e5] disabled:bg-[#5A45FE]/70",
-    secondary: "bg-gray-100 text-gray-900 hover:bg-gray-200",
+    // Add explicit disabled colors for secondary to ensure sufficient contrast
+    secondary: `bg-gray-100 text-gray-900 hover:bg-gray-200 disabled:bg-[${secondaryDisabledBg}] disabled:text-[${secondaryDisabledText}]`,
     outline:
       "border border-gray-300 bg-transparent hover:bg-gray-50 text-gray-700",
   };

--- a/src/components/buttonColors.ts
+++ b/src/components/buttonColors.ts
@@ -1,0 +1,11 @@
+// Centralized color constants for button disabled states so tests and components stay in sync
+export const secondaryDisabledBg = "#E5E7EB"; // Tailwind gray-200
+export const secondaryDisabledText = "#374151"; // Tailwind gray-700
+
+export const primaryDisabledBg = "#5A45FEB3"; // semi-transparent primary (70% alpha expressed as hex8) - kept for reference
+
+export default {
+  secondaryDisabledBg,
+  secondaryDisabledText,
+  primaryDisabledBg,
+};


### PR DESCRIPTION
Closes #176 

Changes I made:
- Button.tsx — Removed disabled:opacity-50, added disabled:cursor-not-allowed, and explicit disabled bg/text styles for secondary.
- buttonColors.ts — Added disabled color constants (#E5E7EB, #374151).
- button-contrast.test.ts — Added contrast test (sRGB) asserting ≥ 3.0.

<img width="742" height="587" alt="image" src="https://github.com/user-attachments/assets/66bcffe0-a732-4140-83ed-aca569bb6ddc" />
