### PR TITLE
Add payment summary utility

### DIFF
--- a/__tests__/paymentSummary.test.ts
+++ b/__tests__/paymentSummary.test.ts
@@ -1,0 +1,51 @@
+import { createPaymentSummary } from "@/lib/paymentSummary";
+
+describe("createPaymentSummary", () => {
+  it("calculates a complete Stripe fee breakdown for USD", () => {
+    expect(createPaymentSummary(100, "usd", "stripe")).toEqual({
+      baseAmount: { amount: 100, currency: "USD" },
+      platformFee: { amount: 5, currency: "USD" },
+      providerFee: { amount: 3.2, currency: "USD" },
+      totalAmount: { amount: 108.2, currency: "USD" },
+    });
+  });
+
+  it("applies Paystack percentage and flat NGN fee", () => {
+    expect(createPaymentSummary(10000, "ngn", "paystack")).toEqual({
+      baseAmount: { amount: 10000, currency: "NGN" },
+      platformFee: { amount: 350, currency: "NGN" },
+      providerFee: { amount: 250, currency: "NGN" },
+      totalAmount: { amount: 10600, currency: "NGN" },
+    });
+  });
+
+  it("falls back to the default platform rate for unsupported currencies", () => {
+    expect(createPaymentSummary(50, "eur", "stripe")).toEqual({
+      baseAmount: { amount: 50, currency: "EUR" },
+      platformFee: { amount: 2, currency: "EUR" },
+      providerFee: { amount: 1.45, currency: "EUR" },
+      totalAmount: { amount: 53.45, currency: "EUR" },
+    });
+  });
+
+  it("rounds fractional amounts consistently", () => {
+    expect(createPaymentSummary(12.345, "usd", "stripe")).toEqual({
+      baseAmount: { amount: 12.35, currency: "USD" },
+      platformFee: { amount: 0.62, currency: "USD" },
+      providerFee: { amount: 0.66, currency: "USD" },
+      totalAmount: { amount: 13.63, currency: "USD" },
+    });
+  });
+
+  it("rejects invalid base amounts", () => {
+    expect(() => createPaymentSummary(-1, "usd", "stripe")).toThrow(
+      "Base amount must be a non-negative finite number",
+    );
+  });
+
+  it("rejects blank currencies", () => {
+    expect(() => createPaymentSummary(10, "   ", "stripe")).toThrow(
+      "Currency is required",
+    );
+  });
+});

--- a/src/lib/paymentSummary.ts
+++ b/src/lib/paymentSummary.ts
@@ -1,0 +1,105 @@
+export type PaymentProvider = "stripe" | "paystack";
+
+type MoneyBreakdown = {
+  amount: number;
+  currency: string;
+};
+
+export type PaymentSummary = {
+  baseAmount: MoneyBreakdown;
+  platformFee: MoneyBreakdown;
+  providerFee: MoneyBreakdown;
+  totalAmount: MoneyBreakdown;
+};
+
+type FeeRule = {
+  percentage: number;
+  flatByCurrency?: Partial<Record<string, number>>;
+};
+
+const DEFAULT_PLATFORM_RATE = 0.04;
+
+const PLATFORM_RATE_BY_CURRENCY: Record<string, number> = {
+  USD: 0.05,
+  CAD: 0.045,
+  GHS: 0.04,
+  NGN: 0.035,
+};
+
+const PROVIDER_FEE_RULES: Record<PaymentProvider, FeeRule> = {
+  stripe: {
+    percentage: 0.029,
+    flatByCurrency: {
+      USD: 0.3,
+      CAD: 0.3,
+      GHS: 0,
+      NGN: 0,
+    },
+  },
+  paystack: {
+    percentage: 0.015,
+    flatByCurrency: {
+      USD: 0,
+      CAD: 0,
+      GHS: 0,
+      NGN: 100,
+    },
+  },
+};
+
+const roundCurrencyAmount = (amount: number): number =>
+  Math.round((amount + Number.EPSILON) * 100) / 100;
+
+const normalizeCurrency = (currency: string): string => currency.trim().toUpperCase();
+
+export const createPaymentSummary = (
+  baseAmount: number,
+  currency: string,
+  provider: PaymentProvider,
+): PaymentSummary => {
+  if (!Number.isFinite(baseAmount) || baseAmount < 0) {
+    throw new Error("Base amount must be a non-negative finite number");
+  }
+
+  const normalizedCurrency = normalizeCurrency(currency);
+  if (!normalizedCurrency) {
+    throw new Error("Currency is required");
+  }
+
+  const providerRule = PROVIDER_FEE_RULES[provider];
+  if (!providerRule) {
+    throw new Error(`Unsupported provider: ${provider}`);
+  }
+
+  const platformRate =
+    PLATFORM_RATE_BY_CURRENCY[normalizedCurrency] ?? DEFAULT_PLATFORM_RATE;
+  const providerFlatFee = providerRule.flatByCurrency?.[normalizedCurrency] ?? 0;
+
+  const roundedBaseAmount = roundCurrencyAmount(baseAmount);
+  const platformFeeAmount = roundCurrencyAmount(roundedBaseAmount * platformRate);
+  const providerFeeAmount = roundCurrencyAmount(
+    roundedBaseAmount * providerRule.percentage + providerFlatFee,
+  );
+  const totalAmount = roundCurrencyAmount(
+    roundedBaseAmount + platformFeeAmount + providerFeeAmount,
+  );
+
+  return {
+    baseAmount: {
+      amount: roundedBaseAmount,
+      currency: normalizedCurrency,
+    },
+    platformFee: {
+      amount: platformFeeAmount,
+      currency: normalizedCurrency,
+    },
+    providerFee: {
+      amount: providerFeeAmount,
+      currency: normalizedCurrency,
+    },
+    totalAmount: {
+      amount: totalAmount,
+      currency: normalizedCurrency,
+    },
+  };
+};


### PR DESCRIPTION
This pull request introduces a new utility for generating payment summaries, including detailed fee breakdowns for different providers and currencies, along with comprehensive unit tests to ensure correctness and input validation.

Payment summary calculation utility:

* Added `createPaymentSummary` function in `paymentSummary.ts` to compute a detailed breakdown of base amount, platform fee, provider fee, and total amount, supporting multiple currencies and both Stripe and Paystack providers. This includes logic for provider-specific fee rules, platform rates by currency, and robust input validation.

Testing and validation:

* Added a complete test suite in `paymentSummary.test.ts` to verify correct fee calculations for various scenarios, including different providers, currencies, rounding behavior, and error handling for invalid inputs.

Closes #168 