### PR TITLE
feat: standardize paginated response helper for all list endpoints

### DIFF
--- a/src/app/api/gifts/route.ts
+++ b/src/app/api/gifts/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { paginatedResponse } from "@/lib/api-utils";
 import { db } from "@/lib/db";
 import { users, gifts } from "@/lib/db/schema";
 import { eq } from "drizzle-orm";
@@ -16,7 +17,7 @@ import { sendGiftConfirmationOTP } from "@/server/services/emailService";
 import { calculateFee } from "@/lib/fees";
 
 export async function GET() {
-  return NextResponse.json({ gifts: [] });
+  return paginatedResponse([], 0, 1, 10);
 }
 
 export async function POST(request: NextRequest) {

--- a/src/app/api/transactions/route.ts
+++ b/src/app/api/transactions/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
+import { paginatedResponse } from "@/lib/api-utils";
 import { db } from "@/lib/db";
 import { gifts } from "@/lib/db/schema";
 import { eq, or, desc, count } from "drizzle-orm";
@@ -103,10 +104,5 @@ export async function GET(request: NextRequest) {
     };
   });
 
-  return NextResponse.json({
-    data: transactions,
-    total,
-    page,
-    limit,
-  });
+  return paginatedResponse(transactions, total, page, limit);
 }

--- a/src/lib/api-utils.ts
+++ b/src/lib/api-utils.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from "next/server";
+
+export function paginatedResponse<T>(
+  data: T[],
+  total: number,
+  page: number,
+  limit: number,
+) {
+  return NextResponse.json({ data, total, page, limit });
+}


### PR DESCRIPTION
Closes #199 

## Summary

Standardizes how paginated responses are returned across all list endpoints by introducing a single reusable helper, eliminating manual and inconsistent response construction.

## Changes

### `src/lib/api-utils.ts` *(new file)*
- Added a generic `paginatedResponse<T>(data, total, page, limit)` utility that wraps `NextResponse.json` and returns a consistently shaped payload.

### `src/app/api/transactions/route.ts`
- Imported `paginatedResponse` from `@/lib/api-utils`.
- Replaced the manually assembled `NextResponse.json({ data, total, page, limit })` call with `paginatedResponse(transactions, total, page, limit)`.

### `src/app/api/gifts/route.ts`
- Imported `paginatedResponse` from `@/lib/api-utils`.
- Replaced the stub `NextResponse.json({ gifts: [] })` with `paginatedResponse([], 0, 1, 10)` to conform to the standardized contract.

## Standardized Response Shape

All list endpoints now consistently return:

```json
{
  "data": [],
  "total": 0,
  "page": 1,
  "limit": 10
}
```

## Testing

- Verified `GET /api/transactions` returns `{ data, total, page, limit }` via the helper.
- Verified `GET /api/gifts` returns the standardized shape.
- No existing logic was altered — only the response assembly point was centralized.
