### PR TITLE
withdraw modal

### DIFF
--- a/src/components/dashboard/dashboard/AccountBalanceCard.tsx
+++ b/src/components/dashboard/dashboard/AccountBalanceCard.tsx
@@ -1,3 +1,5 @@
+"use client";
+
 import {
   BankIcon,
   CoinIcon,
@@ -5,9 +7,15 @@ import {
   MoneyBag,
   WithdrawalIcon,
 } from "@/assets/svg";
+import WithdrawalSuccessModal from "@/components/dashboard/withdrawal/WithdrawalSuccessModal";
 import { Copy } from "lucide-react";
+import { useState } from "react";
+
+const DEMO_WITHDRAWAL_AMOUNT = 250;
 
 export const AccountBalanceCard = () => {
+  const [isWithdrawalSuccessOpen, setIsWithdrawalSuccessOpen] = useState(false);
+
   return (
     <div className="p-6 bg-white w-full sm:max-w-102.25 rounded-4xl space-y-8">
       <div className="space-y-5">
@@ -16,9 +24,9 @@ export const AccountBalanceCard = () => {
             <div className="flex items-center justify-between w-full mb-2">
               <div>
                 <span className="leading-6 text-base text-[#18181B] flex items-center">
-                  <div className="mr-2 inline-flex items-center justify-center size-6 bg-[#F7F7FC] rounded-full ">
+                  <span className="mr-2 inline-flex items-center justify-center size-6 bg-[#F7F7FC] rounded-full ">
                     <MoneyBag />
-                  </div>
+                  </span>
                   Account Balance
                 </span>
               </div>
@@ -38,20 +46,31 @@ export const AccountBalanceCard = () => {
               <div className="bg-[#5A42DE] size-10 rounded-xl flex justify-center items-center">
                 <GiftSentIcon />
               </div>
-              <p className="text-sm leading-5 text-[#18181B] whitespace-nowrap">Send Gift</p>
+              <p className="text-sm leading-5 text-[#18181B] whitespace-nowrap">
+                Send Gift
+              </p>
             </div>
             <div className="flex items-center flex-col gap-2">
               <div className="bg-[#5A42DE] size-10 rounded-xl flex justify-center items-center">
                 <BankIcon />
               </div>
-              <p className="text-sm leading-5 text-[#18181B] whitespace-nowrap">Add a Bank</p>
+              <p className="text-sm leading-5 text-[#18181B] whitespace-nowrap">
+                Add a Bank
+              </p>
             </div>
-            <div className="flex items-center flex-col gap-2">
-              <div className="bg-[#5A42DE] size-10 rounded-xl flex justify-center items-center">
+            <button
+              type="button"
+              onClick={() => setIsWithdrawalSuccessOpen(true)}
+              className="flex items-center flex-col gap-2 rounded-xl focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-[#5A42DE] focus-visible:ring-offset-2"
+              aria-label="Withdraw funds"
+            >
+              <span className="bg-[#5A42DE] size-10 rounded-xl flex justify-center items-center">
                 <WithdrawalIcon />
-              </div>
-              <p className="text-sm leading-5 text-[#18181B] whitespace-nowrap">Withdraw</p>
-            </div>
+              </span>
+              <span className="text-sm leading-5 text-[#18181B] whitespace-nowrap">
+                Withdraw
+              </span>
+            </button>
           </div>
         </div>
       </div>
@@ -73,6 +92,12 @@ export const AccountBalanceCard = () => {
           </div>
         </div>
       </div>
+
+      <WithdrawalSuccessModal
+        isOpen={isWithdrawalSuccessOpen}
+        amount={DEMO_WITHDRAWAL_AMOUNT}
+        onClose={() => setIsWithdrawalSuccessOpen(false)}
+      />
     </div>
   );
 };

--- a/src/components/dashboard/withdrawal/WithdrawalSuccessModal.tsx
+++ b/src/components/dashboard/withdrawal/WithdrawalSuccessModal.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import React, { useEffect, useRef } from "react";
+import { Check } from "lucide-react";
+import { motion, AnimatePresence } from "framer-motion";
+import Button from "@/components/Button";
+import { useFocusTrap } from "@/hooks/useFocusTrap";
+
+type WithdrawalSuccessModalProps = {
+  isOpen: boolean;
+  amount: number;
+  currency?: string;
+  onClose: () => void;
+};
+
+const formatWithdrawalAmount = (amount: number, currency: string) =>
+  new Intl.NumberFormat("en-US", {
+    style: "currency",
+    currency,
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  }).format(amount);
+
+const WithdrawalSuccessModal: React.FC<WithdrawalSuccessModalProps> = ({
+  isOpen,
+  amount,
+  currency = "USD",
+  onClose,
+}) => {
+  const modalRef = useRef<HTMLDivElement>(null);
+
+  useFocusTrap(modalRef, isOpen);
+
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === "Escape" && isOpen) {
+        onClose();
+      }
+    };
+
+    if (isOpen) {
+      document.addEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "hidden";
+    }
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.body.style.overflow = "";
+    };
+  }, [isOpen, onClose]);
+
+  const formattedAmount = formatWithdrawalAmount(amount, currency);
+
+  return (
+    <AnimatePresence>
+      {isOpen ? (
+        <motion.div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 p-4 backdrop-blur-sm"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.2 }}
+          onClick={(event) => {
+            if (event.target === event.currentTarget) {
+              onClose();
+            }
+          }}
+        >
+          <motion.div
+            ref={modalRef}
+            className="w-full max-w-[420px] rounded-3xl bg-white px-6 py-8 text-center shadow-2xl focus:outline-none sm:px-8 sm:py-10"
+            initial={{ opacity: 0, scale: 0.95, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 12 }}
+            transition={{ duration: 0.22, ease: "easeOut" }}
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="withdrawal-success-title"
+            aria-describedby="withdrawal-success-description"
+            tabIndex={-1}
+            onClick={(event) => event.stopPropagation()}
+          >
+            <div className="mx-auto mb-8 flex size-[100px] items-center justify-center rounded-full bg-[#E4FAF0]">
+              <div className="flex size-16 items-center justify-center rounded-full bg-[#00CA71]">
+                <Check className="text-white" size={34} strokeWidth={2.75} />
+              </div>
+            </div>
+
+            <div className="mx-auto mb-8 max-w-[320px]">
+              <h2
+                id="withdrawal-success-title"
+                className="text-[24px] font-semibold leading-tight text-[#18181B] sm:text-[28px]"
+              >
+                Withdrawal successful!
+              </h2>
+              <p
+                id="withdrawal-success-description"
+                className="mt-3 text-[15px] leading-6 text-[#717182] sm:text-base"
+              >
+                Your withdrawal of {formattedAmount} was successful
+              </p>
+            </div>
+
+            <Button
+              type="button"
+              onClick={onClose}
+              className="h-14 w-full rounded-xl bg-[#5A42DE] text-base font-semibold text-white hover:bg-[#4E37CC]"
+            >
+              Done
+            </Button>
+          </motion.div>
+        </motion.div>
+      ) : null}
+    </AnimatePresence>
+  );
+};
+
+export default WithdrawalSuccessModal;


### PR DESCRIPTION
## Summary
Added a clear withdrawal success state to the dashboard withdrawal flow. I created a reusable `WithdrawalSuccessModal` component that displays a centered green checkmark, the title “Withdrawal successful!”, a formatted amount confirmation message, and a Done button. I also wired the existing Withdraw action in the account balance card to open the modal with `$250.00`.

### Related Issue
Closes #222

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
- Ran targeted ESLint on the updated files:
  `npx eslint src/components/dashboard/dashboard/AccountBalanceCard.tsx src/components/dashboard/withdrawal/WithdrawalSuccessModal.tsx`
- Ran a targeted TypeScript check for the changed components.
- Confirmed `/dashboard/sender` compiles and serves locally.

### Screenshots / Videos
<!-- Attach screenshot or recording of the withdrawal success modal here. -->
<img width="1301" height="675" alt="Screenshot 2026-04-27 at 6 24 08 pm" src="https://github.com/user-attachments/assets/173a9b53-e3b6-46f7-b1ec-26a1b0d4ef73" />



## Checklist
- [x] My code follows the [Zendvo Five Principles]
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
