### PR TITLE
feat(withdrawal): add balance selection view with gift balance display

### DIFF
--- a/src/app/dashboard/withdraw/page.tsx
+++ b/src/app/dashboard/withdraw/page.tsx
@@ -1,0 +1,15 @@
+import React from "react";
+import { BalanceSelection } from "@/components/dashboard/withdrawal/BalanceSelection";
+
+import { Metadata } from "next";
+
+export const metadata: Metadata = {
+  title: "Withdraw Gift | Zendvo",
+  description: "Withdraw your gift balance to your bank account.",
+};
+
+const WithdrawPage = () => {
+  return <BalanceSelection />;
+};
+
+export default WithdrawPage;

--- a/src/components/dashboard/withdrawal/BalanceSelection.tsx
+++ b/src/components/dashboard/withdrawal/BalanceSelection.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import React from "react";
+import Card from "../../Card";
+import Button from "../../Button";
+import { ChevronDown } from "lucide-react";
+
+export const BalanceSelection = () => {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-[calc(100vh-120px)] p-4">
+      <div className="w-full max-w-[480px] space-y-8">
+        
+
+        <Card className="p-8 border-none shadow-[0px_8px_30px_rgba(0,0,0,0.04)] rounded-[32px]">
+          <div className="text-left space-y-6">
+          <h1 className="text-3xl font-bold text-[#18181B]">Withdraw your gift</h1>
+          <p className="text-[#717182] text-base ">
+            Choose where you'd like your money sent.
+          </p>
+        </div>
+          <div className="space-y-6 ">
+            {/* Gift Balance Selection */}
+            <div className="space-y-4">
+             
+              <div className="relative flex items-center justify-between p-5 border-2 border-[#5A45FE] rounded-2xl mt-5 bg-[#F7F7FC]">
+                <div className="flex items-center  gap-4">
+                  <div className="flex items-center justify-center w-10 h-10 rounded-full bg-white shadow-sm overflow-hidden border border-gray-100">
+                    <span className="text-xl">🇺🇸</span>
+                  </div>
+                  <div className="space-y-0.5">
+                    <p className="font-bold text-lg text-[#18181B]">USD: $500.00</p>
+                    <p className="text-xs text-[#717182]">Current balance</p>
+                  </div>
+                </div>
+                <div className="flex items-center justify-center w-6 h-6 rounded-full border-2 border-[#5A45FE]">
+                  <div className="w-3 h-3 rounded-full bg-[#5A45FE]"></div>
+                </div>
+              </div>
+            </div>
+
+            {/* Bank Account Selection */}
+            <div className="space-y-4">
+              <div className="w-full relative">
+                <label className="block absolute -top-2.5 left-4 px-1 bg-white text-[11px] text-[#9CA3AF] pointer-events-none z-10">
+                  Select bank account
+                </label>
+                <button className="w-full flex items-center justify-between px-5 py-4 rounded-2xl bg-white border border-[#E5E7EB] text-[#d1d1d8] text-base focus:outline-none focus:ring-1 focus:ring-[#5A45FE] focus:border-[#5A45FE] transition-all">
+                  <span>Select bank account</span>
+                  <ChevronDown className="w-5 h-5 text-[#9CA3AF]" />
+                </button>
+              </div>
+            </div>
+
+            <Button variant="primary" className="w-full py-4 rounded-2xl text-lg font-bold">
+              Continue
+            </Button>
+          </div>
+        </Card>
+      </div>
+    </div>
+  );
+};
+
+


### PR DESCRIPTION
## Summary

Implements the Withdraw Gift Balance Selection View to display the user’s available gift balance before initiating a withdrawal.

A centered card UI shows the balance (currency + amount) along with a placeholder dropdown for selecting a bank account, following the provided Figma design.

---

## Related Issue

Closes #220

---

## Type of Change

- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix  
- [ ] Breaking change  
- [ ] Documentation update  

---

## How Has This Been Tested?

- Verified UI renders correctly on `/dashboard/withdraw`
- Confirmed gift balance is displayed with correct formatting (currency + amount)
- Checked layout alignment and responsiveness of the centered card
- Ensured dropdown placeholder for bank selection is visible and styled correctly

---

## Screenshots / Videos

<img width="1914" height="862" alt="Screenshot 2026-04-28 001106" src="https://github.com/user-attachments/assets/38c4d0c9-6bad-4ca1-9f35-28c1d47aca0c" />
<img width="669" height="852" alt="Screenshot 2026-04-28 000108" src="https://github.com/user-attachments/assets/4c1f8f9b-05f2-4aba-8d9e-930148c7afe4" />


---

## Checklist

- [x] My code follows the Zendvo Five Principles  
- [x] I have performed a self-review of my own code  
- [x] I have commented my code where necessary  
- [x] My changes generate no new warnings  
- [ ] I have made corresponding changes to the documentation  
- [ ] I have added tests that prove my feature works  
- [x] New and existing unit tests pass locally with my changes  