### PR TITLE
feat: add paginated dashboard activity API endpoint

### DIFF
--- a/src/app/api/dashboard/activity/route.ts
+++ b/src/app/api/dashboard/activity/route.ts
@@ -1,0 +1,119 @@
+import { NextRequest, NextResponse } from "next/server";
+import { createProblemDetails, paginatedResponse } from "@/lib/api-utils";
+import { db } from "@/lib/db";
+import { gifts } from "@/lib/db/schema";
+import { eq, or, desc, count, ne } from "drizzle-orm";
+
+const INTEGER_PARAM_REGEX = /^\d+$/;
+
+const isValidPositiveInteger = (value: string): boolean =>
+  INTEGER_PARAM_REGEX.test(value) && Number.parseInt(value, 10) >= 1;
+
+export async function GET(request: NextRequest) {
+  // Authentication check
+  const userId = request.headers.get("x-user-id");
+  if (!userId) {
+    return createProblemDetails(
+      "about:blank",
+      "Unauthorized",
+      401,
+      "Unauthorized",
+    );
+  }
+
+  const { searchParams } = request.nextUrl;
+
+  // Parse pagination parameters
+  const pageParam = searchParams.get("page") ?? "1";
+  const limitParam = searchParams.get("limit") ?? "10";
+
+  // Validate pagination parameters
+  if (
+    !isValidPositiveInteger(pageParam) ||
+    !isValidPositiveInteger(limitParam)
+  ) {
+    return createProblemDetails(
+      "about:blank",
+      "Bad Request",
+      400,
+      "page must be >= 1 and limit must be between 1 and 100",
+    );
+  }
+
+  const page = Number.parseInt(pageParam, 10);
+  const limit = Number.parseInt(limitParam, 10);
+
+  if (limit > 100) {
+    return createProblemDetails(
+      "about:blank",
+      "Bad Request",
+      400,
+      "page must be >= 1 and limit must be between 1 and 100",
+    );
+  }
+
+  try {
+    // Query for both sent and received gifts, excluding failed transactions
+    const whereClause = or(
+      eq(gifts.senderId, userId),
+      eq(gifts.recipientId, userId),
+    );
+
+    const [giftRows, [{ value: total }]] = await Promise.all([
+      db.query.gifts.findMany({
+        where: whereClause,
+        limit,
+        offset: (page - 1) * limit,
+        orderBy: [desc(gifts.createdAt)],
+        with: {
+          sender: { columns: { id: true, name: true, email: true } },
+          recipient: { columns: { id: true, name: true, email: true } },
+        },
+      }),
+      db.select({ value: count() }).from(gifts).where(whereClause),
+    ]);
+
+    // Transform the data for the dashboard table
+    const activities = giftRows.map((gift: (typeof giftRows)[number]) => {
+      const isSender = gift.senderId === userId;
+      const counterparty = isSender
+        ? gift.recipient
+        : (gift.sender ?? {
+            id: null,
+            name: gift.senderName ?? "External Sender",
+            email: gift.senderEmail ?? null,
+          });
+
+      return {
+        giftId: gift.id,
+        date:
+          gift.createdAt instanceof Date
+            ? gift.createdAt.toISOString()
+            : gift.createdAt,
+        amount: gift.amount,
+        currency: gift.currency,
+        status: gift.status,
+        type: isSender ? "sent" : "received",
+        counterparty: {
+          id: counterparty.id,
+          name: counterparty.name,
+          email: counterparty.email,
+        },
+        message: gift.message,
+        isAnonymous: gift.isAnonymous,
+        hideSender: gift.hideSender,
+        hideAmount: gift.hideAmount,
+      };
+    });
+
+    return paginatedResponse(activities, total, page, limit);
+  } catch (error) {
+    console.error("Dashboard activity error:", error);
+    return createProblemDetails(
+      "about:blank",
+      "Internal Server Error",
+      500,
+      "Internal server error",
+    );
+  }
+}


### PR DESCRIPTION
- Create GET /api/dashboard/activity endpoint for recent gift transactions
- Support pagination with page and limit query parameters
- Return gift ID, date, amount, currency, and status for each transaction
- Include both sent and received gifts ordered by creation date
- Add type field to distinguish between sent/received transactions
- Include counterparty information (sender/recipient details)
- Validate pagination parameters (page >= 1, limit 1-100)
- Handle authentication via x-user-id header
- Return proper error responses for unauthorized and invalid requests

## Summary
<!-- Briefly describe the problem and your proposed solution. -->

### Related Issue
<!-- Link the related issue here using 'Closes #XXX' -->
Closes #

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

### Screenshots / Videos
<!-- If this is a UI change, please attach screenshots or screen recordings. -->

## Checklist
- [ ] My code follows the [Zendvo Five Principles]
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes


Closes #248