### PR TITLE
Connected Bank Account API done

### DIFF
--- a/src/app/api/wallet/banks/route.ts
+++ b/src/app/api/wallet/banks/route.ts
@@ -1,0 +1,64 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { bankAccounts } from "@/lib/db/schema";
+import { getAuthPayload } from "@/lib/auth-session";
+import { addBankAccountSchema } from "@/lib/validations/bank";
+
+export async function POST(req: NextRequest) {
+  try {
+    const payload = await getAuthPayload(req);
+    if (!payload?.userId) {
+      return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+
+    const body = await req.json();
+    const validationResult = addBankAccountSchema.safeParse(body);
+
+    if (!validationResult.success) {
+      return NextResponse.json(
+        { error: "Invalid payload", details: validationResult.error.format() },
+        { status: 400 }
+      );
+    }
+
+    const data = validationResult.data;
+
+    // Mask account number for response
+    const maskedAccountNumber =
+      data.accountNumber.length > 4
+        ? "****" + data.accountNumber.slice(-4)
+        : "****";
+
+    const [bankAccount] = await db
+      .insert(bankAccounts)
+      .values({
+        userId: payload.userId,
+        country: data.country,
+        currency: data.currency,
+        swiftBic: data.swiftBic,
+        accountNumber: data.accountNumber,
+      })
+      .returning();
+
+    return NextResponse.json(
+      {
+        message: "Bank account added successfully",
+        bankAccount: {
+          id: bankAccount.id,
+          country: bankAccount.country,
+          currency: bankAccount.currency,
+          swiftBic: bankAccount.swiftBic,
+          accountNumber: maskedAccountNumber,
+          createdAt: bankAccount.createdAt,
+        },
+      },
+      { status: 201 }
+    );
+  } catch (error) {
+    console.error("Error adding bank account:", error);
+    return NextResponse.json(
+      { error: "Internal server error" },
+      { status: 500 }
+    );
+  }
+}

--- a/src/lib/db/schema.ts
+++ b/src/lib/db/schema.ts
@@ -227,6 +227,26 @@ export const notifications = pgTable(
   },
 );
 
+export const bankAccounts = pgTable(
+  "bank_accounts",
+  {
+    id: uuid("id").defaultRandom().primaryKey(),
+    userId: uuid("user_id")
+      .notNull()
+      .references(() => users.id),
+    country: text("country").notNull(),
+    currency: text("currency").notNull(),
+    swiftBic: text("swift_bic").notNull(),
+    accountNumber: text("account_number").notNull(),
+    createdAt: timestamp("created_at").defaultNow().notNull(),
+    updatedAt: timestamp("updated_at").defaultNow().notNull(),
+  },
+  (table) => {
+    return [
+      index("bank_accounts_user_id_idx").on(table.userId),
+    ];
+  },
+);
 
 export const usersRelations = relations(users, ({ many }) => ({
   emailVerifications: many(emailVerifications),
@@ -235,6 +255,7 @@ export const usersRelations = relations(users, ({ many }) => ({
   sentGifts: many(gifts, { relationName: "sentGifts" }),
   receivedGifts: many(gifts, { relationName: "receivedGifts" }),
   wallets: many(wallets),
+  bankAccounts: many(bankAccounts),
   notifications: many(notifications),
 }));
 
@@ -285,6 +306,13 @@ export const walletsRelations = relations(wallets, ({ one }) => ({
 export const notificationsRelations = relations(notifications, ({ one }) => ({
   user: one(users, {
     fields: [notifications.userId],
+    references: [users.id],
+  }),
+}));
+
+export const bankAccountsRelations = relations(bankAccounts, ({ one }) => ({
+  user: one(users, {
+    fields: [bankAccounts.userId],
     references: [users.id],
   }),
 }));

--- a/src/lib/validations/bank.ts
+++ b/src/lib/validations/bank.ts
@@ -1,0 +1,13 @@
+import { z } from "zod";
+
+export const addBankAccountSchema = z.object({
+  country: z.string().min(2, "Country is required"),
+  currency: z.string().length(3, "Currency must be a 3-letter code"),
+  swiftBic: z
+    .string()
+    .min(8, "SWIFT/BIC must be at least 8 characters")
+    .max(11, "SWIFT/BIC must be at most 11 characters"),
+  accountNumber: z.string().min(5, "Account number is required"),
+});
+
+export type AddBankAccountInput = z.infer<typeof addBankAccountSchema>;


### PR DESCRIPTION
closes #250.
Successfully added the api endpoint for users to save their  fiat bank account details to their wallet.

Changes Made
1. Database Schema
Modified: src/lib/db/schema.ts
Added a new bankAccounts table to store the bank details (country, currency, swiftBic, accountNumber) linked to a user.
Set up a one-to-many relationship from users to bankAccounts.
2. Payload Validation
Created: src/lib/validations/bank.ts
Implemented a zod schema addBankAccountSchema to ensure strict validation of the incoming payload before storing it in the database.
Ensures the currency is exactly 3 letters, swiftBic is valid, and the required fields are present.
3. API Endpoint
Created: src/app/api/wallet/banks/route.ts
Added a POST handler for the /api/wallet/banks endpoint.
Validates user session using the existing getAuthPayload utility to securely identify the user.
Parses and validates the request body.
Inserts the bank account into the bankAccounts table via Drizzle ORM.
Returns a 201 Created status with the newly created bank account details, masking the accountNumber (e.g., ****1234) in the API response for security.
