### PR TITLE
feat: add GET /api/users/me/account-details endpoint

### DIFF
--- a/backend/src/api/users/me/account-details/route.ts
+++ b/backend/src/api/users/me/account-details/route.ts
@@ -1,0 +1,54 @@
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+import { getAuthPayload } from "@/lib/auth-session";
+import { createProblemDetails } from "@/lib/api-utils";
+
+export async function GET(request: NextRequest) {
+  try {
+    const payload = await getAuthPayload(request);
+    if (!payload) {
+      return createProblemDetails(
+        "about:blank",
+        "Unauthorized",
+        401,
+        "Unauthorized",
+      );
+    }
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.id, payload.userId),
+      columns: {
+        name: true,
+        phoneNumber: true,
+      },
+    });
+
+    if (!user) {
+      return createProblemDetails(
+        "about:blank",
+        "Not Found",
+        404,
+        "User not found",
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        name: user.name,
+        accountNumber: user.phoneNumber,
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("Error in users/me/account-details:", error);
+    return createProblemDetails(
+      "about:blank",
+      "Internal Server Error",
+      500,
+      "Internal server error",
+    );
+  }
+}

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -19,6 +19,9 @@ import { POST as sendVerificationPost } from "./api/auth/send-verification/route
 import { POST as verifyEmailPost } from "./api/auth/verify-email/route";
 import { POST as verifyOtpPost } from "./api/auth/verify-otp/route";
 
+// Users
+import { GET as accountDetailsGet } from "./api/users/me/account-details/route";
+
 export const apiRouter = Router();
 
 // 1. Authentication routes
@@ -38,4 +41,7 @@ apiRouter.post("/api/auth/send-phone-otp", makeExpressHandler(sendPhoneOtpPost))
 apiRouter.post("/api/auth/send-verification", makeExpressHandler(sendVerificationPost));
 apiRouter.post("/api/auth/verify-email", makeExpressHandler(verifyEmailPost));
 apiRouter.post("/api/auth/verify-otp", makeExpressHandler(verifyOtpPost));
+
+// 2. User routes
+apiRouter.get("/api/users/me/account-details", makeExpressHandler(accountDetailsGet));
 


### PR DESCRIPTION
## Summary

- Adds `GET /api/users/me/account-details` — a new authenticated endpoint that returns the logged-in user's `name` and `accountNumber` (their registered phone number).
- Registers the route in `routes.ts` under a new "User routes" section.
- No schema changes required; reads from the existing `phoneNumber` column on the `users` table.

Closes #269

## Endpoint

**Request**
```
GET /api/users/me/account-details
Authorization: Bearer <access_token>
```

**Response `200`**
```json
{
  "success": true,
  "name": "Jane Doe",
  "accountNumber": "+2348012345678"
}
```

**Errors**
| Status | Reason |
|--------|--------|
| 401 | Missing or invalid token |
| 404 | User not found |
| 500 | Internal server error |

## Test plan

- [ ] Authenticated request returns `name` and `accountNumber` matching the logged-in user's DB record
- [ ] Request without a token returns `401`
- [ ] CI passes: lint, type-check, tests, build
