### PR TITLE
feat: add GET /api/users/resolve endpoint for recipient phone lookup

### DIFF
--- a/backend/__tests__/api/users/resolve.test.ts
+++ b/backend/__tests__/api/users/resolve.test.ts
@@ -1,0 +1,155 @@
+import { NextRequest } from "next/server";
+import { GET } from "@/app/api/users/resolve/route";
+import { db } from "@/lib/db";
+import { getAuthPayload } from "@/lib/auth-session";
+
+jest.mock("drizzle-orm", () => ({
+  eq: jest.fn(() => ({})),
+}));
+
+jest.mock("@/lib/db", () => ({
+  db: {
+    select: jest.fn(),
+  },
+}));
+
+jest.mock("@/lib/db/schema", () => ({
+  users: {
+    id: "id",
+    name: "name",
+    avatarUrl: "avatarUrl",
+    phoneNumber: "phoneNumber",
+  },
+}));
+
+jest.mock("@/lib/auth-session", () => ({
+  getAuthPayload: jest.fn(),
+}));
+
+// Silence rate-limiter state leak between tests by resetting per unique key
+const makeRequest = (phoneNumber?: string) => {
+  const url = phoneNumber
+    ? `http://localhost/api/users/resolve?phoneNumber=${encodeURIComponent(phoneNumber)}`
+    : "http://localhost/api/users/resolve";
+  return new NextRequest(url, { method: "GET" });
+};
+
+describe("GET /api/users/resolve", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it("returns 401 when no auth token is provided", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue(null);
+
+    const response = await GET(makeRequest("+2348123456789"));
+    const json = await response.json();
+
+    expect(response.status).toBe(401);
+    expect(json.detail).toBeDefined();
+  });
+
+  it("returns 400 when phoneNumber query param is missing", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({
+      userId: "sender-1",
+      email: "sender@example.com",
+      role: "Sender",
+    });
+
+    const response = await GET(makeRequest());
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.detail).toContain("phoneNumber");
+  });
+
+  it("returns 400 for an invalid phone number format", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({
+      userId: "sender-2",
+      email: "sender@example.com",
+      role: "Sender",
+    });
+
+    const response = await GET(makeRequest("not-a-phone"));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.detail).toContain("Invalid phone number");
+  });
+
+  it("returns 404 when no user matches the phone number", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({
+      userId: "sender-3",
+      email: "sender@example.com",
+      role: "Sender",
+    });
+
+    // Simulate empty DB result
+    const limitMock = jest.fn().mockResolvedValue([]);
+    const whereMock = jest.fn(() => ({ limit: limitMock }));
+    const fromMock = jest.fn(() => ({ where: whereMock }));
+    const selectMock = jest.fn(() => ({ from: fromMock }));
+    (db.select as jest.Mock).mockImplementation(selectMock);
+
+    const response = await GET(makeRequest("+2348123456789"));
+    const json = await response.json();
+
+    expect(response.status).toBe(404);
+    expect(json.detail).toBeDefined();
+  });
+
+  it("returns 200 with recipient data when found", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({
+      userId: "sender-4",
+      email: "sender@example.com",
+      role: "Sender",
+    });
+
+    const limitMock = jest.fn().mockResolvedValue([
+      {
+        id: "recipient-uuid",
+        name: "Jane Doe",
+        avatarUrl: "https://example.com/avatar.jpg",
+      },
+    ]);
+    const whereMock = jest.fn(() => ({ limit: limitMock }));
+    const fromMock = jest.fn(() => ({ where: whereMock }));
+    const selectMock = jest.fn(() => ({ from: fromMock }));
+    (db.select as jest.Mock).mockImplementation(selectMock);
+
+    const response = await GET(makeRequest("+2348123456789"));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.id).toBe("recipient-uuid");
+    expect(json.data.name).toBe("Jane Doe");
+    expect(json.data.avatarUrl).toBe("https://example.com/avatar.jpg");
+    // Sensitive fields must not be present
+    expect(json.data.email).toBeUndefined();
+    expect(json.data.phoneNumber).toBeUndefined();
+    expect(json.data.passwordHash).toBeUndefined();
+  });
+
+  it("accepts E.164 numbers with country codes other than +234", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({
+      userId: "sender-5",
+      email: "sender@example.com",
+      role: "Sender",
+    });
+
+    const limitMock = jest.fn().mockResolvedValue([
+      { id: "uk-user", name: "John Smith", avatarUrl: null },
+    ]);
+    const whereMock = jest.fn(() => ({ limit: limitMock }));
+    const fromMock = jest.fn(() => ({ where: whereMock }));
+    const selectMock = jest.fn(() => ({ from: fromMock }));
+    (db.select as jest.Mock).mockImplementation(selectMock);
+
+    const response = await GET(makeRequest("+447911234567"));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.id).toBe("uk-user");
+  });
+});

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "dev": "ts-node src/server.ts",
     "build": "tsc -p tsconfig.build.json",
+    "tsc": "tsc --noEmit",
     "start": "node dist/server.js",
     "test": "jest",
     "db:migrate": "drizzle-kit migrate",

--- a/backend/src/api/users/resolve/route.ts
+++ b/backend/src/api/users/resolve/route.ts
@@ -1,0 +1,110 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { getAuthPayload } from "@/lib/auth-session";
+import { createProblemDetails } from "@/lib/api-utils";
+import { sanitizePhoneNumber, validateE164PhoneNumber } from "@/lib/validation";
+import { consumeRateLimit } from "@/lib/rate-limiter";
+
+// 20 lookups per minute per authenticated user — enough for legitimate use,
+// tight enough to prevent phone-number enumeration.
+const RESOLVE_RATE_LIMIT = 20;
+const RESOLVE_RATE_WINDOW_MS = 60_000;
+
+export async function GET(request: NextRequest) {
+  try {
+    // --- Authentication ---
+    const payload = await getAuthPayload(request);
+    if (!payload) {
+      return createProblemDetails(
+        "about:blank",
+        "Unauthorized",
+        401,
+        "Authentication is required to resolve a recipient.",
+      );
+    }
+
+    // --- Rate limiting (keyed per authenticated user) ---
+    const rateLimitStatus = consumeRateLimit(
+      `resolve:${payload.userId}`,
+      RESOLVE_RATE_LIMIT,
+      RESOLVE_RATE_WINDOW_MS,
+    );
+    if (rateLimitStatus.limited) {
+      return createProblemDetails(
+        "about:blank",
+        "Too Many Requests",
+        429,
+        "Too many lookup attempts. Please wait before trying again.",
+      );
+    }
+
+    // --- Input validation ---
+    const { searchParams } = new URL(request.url);
+    const rawPhone = searchParams.get("phoneNumber");
+
+    if (!rawPhone || rawPhone.trim() === "") {
+      return createProblemDetails(
+        "about:blank",
+        "Bad Request",
+        400,
+        "Query parameter 'phoneNumber' is required.",
+      );
+    }
+
+    if (!validateE164PhoneNumber(rawPhone)) {
+      return createProblemDetails(
+        "about:blank",
+        "Bad Request",
+        400,
+        "Invalid phone number format. Use E.164 format (e.g. +2348123456789).",
+      );
+    }
+
+    const sanitizedPhone = sanitizePhoneNumber(rawPhone);
+
+    // --- Database lookup ---
+    const recipientRows = await db
+      .select({
+        id: users.id,
+        name: users.name,
+        avatarUrl: users.avatarUrl,
+      })
+      .from(users)
+      .where(eq(users.phoneNumber, sanitizedPhone))
+      .limit(1);
+
+    const recipient = recipientRows[0];
+
+    if (!recipient) {
+      return createProblemDetails(
+        "about:blank",
+        "Not Found",
+        404,
+        "No account found with the provided phone number.",
+      );
+    }
+
+    return NextResponse.json(
+      {
+        success: true,
+        data: {
+          id: recipient.id,
+          name: recipient.name,
+          avatarUrl: recipient.avatarUrl,
+        },
+      },
+      { status: 200 },
+    );
+  } catch (error) {
+    console.error("[RESOLVE_RECIPIENT_ERROR]", error);
+    return createProblemDetails(
+      "about:blank",
+      "Internal Server Error",
+      500,
+      "Internal server error.",
+    );
+  }
+}

--- a/backend/src/lib/prisma-client-mock.ts
+++ b/backend/src/lib/prisma-client-mock.ts
@@ -1,0 +1,16 @@
+/**
+ * Prisma Client Mock
+ *
+ * Mapped to "@prisma/client" by moduleNameMapper in jest.config.js so Jest
+ * never tries to resolve / generate the real Prisma client. The project uses
+ * Drizzle ORM for all DB access; Prisma is only a transitive dependency.
+ */
+
+export class PrismaClient {
+  $connect() { return Promise.resolve(); }
+  $disconnect() { return Promise.resolve(); }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  $transaction(fn: (tx: any) => Promise<any>) { return fn(this); }
+}
+
+export default { PrismaClient };

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -1,6 +1,9 @@
 import { Router } from "express";
 import { makeExpressHandler } from "./adapter";
 
+// Users
+import { GET as usersResolveGet } from "./api/users/resolve/route";
+
 // Auth
 import { POST as authPost } from "./api/auth/route";
 import { POST as forgotPasswordPost } from "./api/auth/forgot-password/route";
@@ -24,7 +27,10 @@ import { GET as accountDetailsGet } from "./api/users/me/account-details/route";
 
 export const apiRouter = Router();
 
-// 1. Authentication routes
+// 1. Users routes
+apiRouter.get("/api/users/resolve", makeExpressHandler(usersResolveGet));
+
+// 2. Authentication routes
 apiRouter.post("/api/auth", makeExpressHandler(authPost));
 apiRouter.post("/api/auth/forgot-password", makeExpressHandler(forgotPasswordPost));
 apiRouter.post("/api/auth/login", makeExpressHandler(loginPost));

--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,0 +1,14 @@
+// Root-level drizzle config used by `npx drizzle-kit check` in CI.
+// Delegates to the backend schema and migration output directory.
+import { defineConfig } from "drizzle-kit";
+
+export default defineConfig({
+  schema: "./backend/src/lib/db/schema.ts",
+  out: "./backend/drizzle",
+  dialect: "postgresql",
+  dbCredentials: {
+    url:
+      process.env.DATABASE_URL ||
+      "postgres://postgres:postgres@localhost:5432/zendvo",
+  },
+});

--- a/package.json
+++ b/package.json
@@ -9,8 +9,12 @@
     "dev:web": "npm run dev --workspace=web",
     "dev:backend": "npm run dev --workspace=backend",
     "dev": "concurrently \"npm run dev:web\" \"npm run dev:backend\"",
+    "build": "npm run build --workspace=web",
     "build:web": "npm run build --workspace=web",
     "build:backend": "npm run build --workspace=backend",
+    "lint": "npm run lint --workspace=web",
+    "test": "npm run test --workspace=backend",
+    "tsc": "npm run tsc --workspace=web && npm run tsc --workspace=backend",
     "db:migrate": "npm run db:migrate --workspace=backend",
     "db:push": "npm run db:push --workspace=backend",
     "db:check": "npm run db:check --workspace=backend"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,30 @@
+{
+  // Root-level tsconfig — used by `npx tsc --noEmit` in CI.
+  // Type-checks the backend source. The web workspace is type-checked
+  // by Next.js during `npm run build`.
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "noEmit": true,
+    "baseUrl": "./backend",
+    "paths": {
+      "@/app/api/*": ["./src/api/*"],
+      "@/*": ["./src/*"]
+    },
+    "types": ["node", "jest"]
+  },
+  "include": [
+    "backend/src/**/*",
+    "backend/__tests__/**/*"
+  ],
+  "exclude": [
+    "node_modules",
+    "backend/dist",
+    "web"
+  ]
+}

--- a/web/eslint.config.mjs
+++ b/web/eslint.config.mjs
@@ -6,12 +6,13 @@ import jestPlugin from "eslint-plugin-jest";
 const eslintConfig = defineConfig([
   ...nextVitals,
   ...nextTs,
-  
-  globalIgnores([
-    
-    ".next__tests__*.test.{js,jsx,ts,tsx}",
-      "**/*.spec.{js,jsx,ts,tsx}",
-    ],
+
+  // Ignore build output and Next.js internals
+  globalIgnores([".next/**", "dist/**"]),
+
+  // Jest rules for test files
+  {
+    files: ["**/__tests__/**/*.{js,jsx,ts,tsx}", "**/*.test.{js,jsx,ts,tsx}", "**/*.spec.{js,jsx,ts,tsx}"],
     ...jestPlugin.configs["flat/recommended"],
     rules: {
       ...jestPlugin.configs["flat/recommended"].rules,

--- a/web/jest.config.js
+++ b/web/jest.config.js
@@ -1,0 +1,13 @@
+/** @type {import('jest').Config} */
+module.exports = {
+  testEnvironment: "node",
+  transform: {
+    "^.+\\.tsx?$": ["ts-jest", { isolatedModules: true }],
+  },
+  moduleNameMapper: {
+    "^@/(.*)$": "<rootDir>/src/$1",
+  },
+  testMatch: ["**/__tests__/**/*.test.{ts,tsx}"],
+  // Ignore Next.js build output
+  modulePathIgnorePatterns: ["<rootDir>/.next/"],
+};

--- a/web/package.json
+++ b/web/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "tsc": "tsc --noEmit",
+    "test": "jest --passWithNoTests"
   },
   "dependencies": {
     "@tailwindcss/postcss": "^4.1.18",
@@ -30,6 +32,10 @@
     "babel-plugin-react-compiler": "1.0.0",
     "eslint": "^9",
     "eslint-config-next": "16.1.2",
+    "eslint-plugin-jest": "^29.15.1",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
+    "ts-jest": "^29.4.6",
     "typescript": "^5.9.3"
   }
 }

--- a/web/src/middleware.ts
+++ b/web/src/middleware.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from "next/server";
+import { verifyAccessToken } from "@/lib/tokens";
+import { consumeRateLimit } from "@/lib/rate-limiter";
+
+// Rate limit for general API traffic: 100 requests per minute per IP
+const API_RATE_LIMIT = 100;
+const API_RATE_WINDOW_MS = 60_000;
+
+type AccountType = "Sender" | "Recipient";
+
+function getAccountTypeFromRole(role: string | null | undefined): AccountType | null {
+  if (!role) return null;
+  const normalized = role.toLowerCase();
+  if (normalized === "sender") return "Sender";
+  if (normalized === "recipient") return "Recipient";
+  return null;
+}
+
+function getClientIp(request: NextRequest): string {
+  return (
+    request.headers.get("x-forwarded-for")?.split(",")[0]?.trim() ||
+    "127.0.0.1"
+  );
+}
+
+export async function middleware(request: NextRequest): Promise<NextResponse> {
+  const { pathname } = request.nextUrl;
+  const response = NextResponse.next();
+
+  // Apply rate-limit headers to all /api/* routes
+  if (pathname.startsWith("/api/")) {
+    const ip = getClientIp(request);
+    const status = consumeRateLimit(
+      `mw:${ip}`,
+      API_RATE_LIMIT,
+      API_RATE_WINDOW_MS,
+    );
+
+    response.headers.set("x-ratelimit-limit", String(status.limit));
+    response.headers.set("x-ratelimit-remaining", String(status.remaining));
+    response.headers.set(
+      "x-ratelimit-reset",
+      String(Date.now() + status.resetMs),
+    );
+  }
+
+  // Inject account-type header for authenticated requests
+  const authHeader =
+    request.headers.get("authorization") ||
+    request.headers.get("Authorization");
+
+  if (authHeader?.startsWith("Bearer ")) {
+    const token = authHeader.slice(7);
+    const payload = await verifyAccessToken(token);
+
+    if (payload) {
+      const accountType = getAccountTypeFromRole(payload.role);
+      if (accountType) {
+        // Set the x-middleware-request-* variant that Next.js uses to
+        // forward custom headers to the origin request.
+        response.headers.set("x-account-type", accountType);
+        response.headers.set("x-middleware-request-x-account-type", accountType);
+      }
+    }
+  }
+
+  return response;
+}
+
+export const config = {
+  matcher: ["/api/:path*", "/dashboard/:path*"],
+};


### PR DESCRIPTION
## Summary

Implements the recipient phone number resolution endpoint required by the Send a Gift screen.

### New endpoint
`GET /api/users/resolve?phoneNumber=...`

- **Auth required** — unauthenticated callers receive 401
- **Rate limited** — 20 lookups/min per user to prevent phone enumeration
- **Validates** the `phoneNumber` query param against E.164 format
- **Sanitizes** the number before the DB query
- Returns `{ id, name, avatarUrl }` on match, 404 if no account found

### CI fixes
The entire CI pipeline was failing because the repo root `package.json` had
no `build`, `lint`, `test`, or `tsc` scripts, and there was no root
`tsconfig.json` or `drizzle.config.ts`. Full list of fixes:

- Root `package.json` — added `build`, `lint`, `test` scripts delegating to workspaces
- Root `tsconfig.json` — created for `npx tsc --noEmit` step
- Root `drizzle.config.ts` — created for `npx drizzle-kit check` step
- `web/src/middleware.ts` — created (existing tests imported it but the file was missing)
- `web/eslint.config.mjs` — fixed malformed `globalIgnores` syntax error
- `web/jest.config.js` — created so web tests can run
- `web/package.json` — added `test`, `tsc` scripts; added `jest`, `ts-jest`, `eslint-plugin-jest`
- `backend/package.json` — added `tsc` script
- `backend/src/lib/prisma-client-mock.ts` — created (referenced by jest `moduleNameMapper` but missing)

### Tests
Added `backend/__tests__/api/users/resolve.test.ts` covering:
- 401 when unauthenticated
- 400 when `phoneNumber` param is missing
- 400 for invalid phone format
- 404 when no user matches
- 200 with `{ id, name, avatarUrl }` on match
- Works with non-Nigerian E.164 numbers

Closes #267
