### PR TITLE
fix(account-details): include defaultCurrency in recipient response payload

### DIFF
--- a/backend/src/api/users/me/account-details/route.ts
+++ b/backend/src/api/users/me/account-details/route.ts
@@ -39,6 +39,7 @@ export async function GET(request: NextRequest) {
         success: true,
         name: user.name,
         accountNumber: user.phoneNumber,
+        defaultCurrency: "USDT",
       },
       { status: 200 },
     );


### PR DESCRIPTION
## Summary

Add `defaultCurrency` field to the `GET /api/users/me/account-details` response payload to satisfy the frontend confirmation card requirements.

## Changes

- Returns `defaultCurrency: "USDT"` alongside `name` and `accountNumber` in the account-details response

## Notes

No `wallets` table exists in the schema yet, so a hardcoded `"USDT"` default is returned as agreed. This can be replaced with a proper wallets join once that table is added.

Closes #287
