### PR TITLE
feat(contracts): implement GiftContract struct and secure initialize function

### DIFF
--- a/contracts/src/gift/contract.rs
+++ b/contracts/src/gift/contract.rs
@@ -1,2 +1,24 @@
-// Defines the smart contract interface and entry points for time-locked gifts.
-// Contains functions for creating a gift, claiming a gift, and checking lock status.
+use soroban_sdk::{contract, contractimpl, Address, Env};
+
+use crate::gift::types::DataKey;
+
+/// Entry point for the time-locked gift contract.
+#[contract]
+pub struct GiftContract;
+
+#[contractimpl]
+impl GiftContract {
+    /// Initializes the contract with a backend admin address.
+    ///
+    /// Must be called exactly once immediately after deployment.
+    /// Reverts if the admin has already been set, preventing any actor
+    /// from overwriting admin rights post-deployment.
+    pub fn initialize(env: Env, admin: Address) {
+        // Guard: panic if already initialized to prevent admin hijacking.
+        if env.storage().instance().has(&DataKey::Admin) {
+            panic!("already initialized");
+        }
+
+        env.storage().instance().set(&DataKey::Admin, &admin);
+    }
+}

--- a/contracts/src/gift/types.rs
+++ b/contracts/src/gift/types.rs
@@ -1,2 +1,8 @@
-// Defines the custom data structures and types used by the gift module.
-// e.g., Gift struct, DataKey enum for storage mapping.
+use soroban_sdk::contracttype;
+
+/// Storage keys for the gift contract's instance storage.
+#[contracttype]
+pub enum DataKey {
+    /// The privileged admin address, set once at initialization.
+    Admin,
+}


### PR DESCRIPTION
Closes #292
## Summary

Implements the foundational structure for the gift smart contract on Soroban.

- Defines `DataKey` enum with `Admin` variant in `gift/types.rs` using `#[contracttype]`
- Creates `GiftContract` struct with the `#[contract]` macro in `gift/contract.rs`
- Implements a one-shot `initialize(env, admin)` function guarded by an instance storage check
- Panics on re-initialization to prevent any actor from overwriting admin rights post-deployment




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added one-time initialization for the gift contract.
  * Administrators can now be configured and stored securely during setup.
  * Prevents reinitialization after an administrator has been set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->