### PR TITLE
Feat/issue 312 event timestamps

### DIFF
--- a/.github/workflows/smart-contracts-ci.yml
+++ b/.github/workflows/smart-contracts-ci.yml
@@ -4,11 +4,13 @@ on:
   push:
     branches: [main, master, develop]
     paths:
-      - 'smart_contracts/**'
+      - 'contracts/**'
+      - '.github/workflows/smart-contracts-ci.yml'
   pull_request:
     branches: [main, master, develop]
     paths:
-      - 'smart_contracts/**'
+      - 'contracts/**'
+      - '.github/workflows/smart-contracts-ci.yml'
 
 jobs:
   build-and-test:
@@ -16,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     defaults:
       run:
-        working-directory: ./smart_contracts
+        working-directory: ./contracts
 
     steps:
       - name: Checkout Repository
@@ -25,22 +27,22 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: wasm32-unknown-unknown
+          targets: wasm32v1-none
           components: clippy, rustfmt
 
       - name: Cache Cargo Registry
         uses: Swatinem/rust-cache@v2
         with:
-          workspaces: "./smart_contracts"
+          workspaces: "./contracts"
 
       - name: Check Formatting
         run: cargo fmt -- --check
 
       - name: Clippy Lints
-        run: cargo clippy --all-targets --all-features -- -D warnings
+        run: cargo clippy --all-targets --all-features --locked -- -D warnings
 
       - name: Run Tests
-        run: cargo test
+        run: cargo test --locked
 
       - name: Build Wasm
-        run: cargo build --target wasm32-unknown-unknown --release
+        run: cargo build --locked --target wasm32v1-none --release

--- a/contracts/Cargo.lock
+++ b/contracts/Cargo.lock
@@ -72,7 +72,7 @@ dependencies = [
  "ark-serialize",
  "ark-std",
  "derivative",
- "digest 0.10.7",
+ "digest",
  "itertools",
  "num-bigint",
  "num-traits",
@@ -125,7 +125,7 @@ checksum = "adb7b85a02b83d2f22f89bd5cac66c9c89474240cb6207cb1efc16d098e822a5"
 dependencies = [
  "ark-serialize-derive",
  "ark-std",
- "digest 0.10.7",
+ "digest",
  "num-bigint",
 ]
 
@@ -187,15 +187,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
 dependencies = [
  "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
-dependencies = [
- "hybrid-array",
 ]
 
 [[package]]
@@ -275,15 +266,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "cpufeatures"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "crate-git-revision"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -301,7 +283,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
  "zeroize",
 ]
@@ -314,16 +296,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-common"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
-dependencies = [
- "hybrid-array",
- "rand_core 0.10.1",
 ]
 
 [[package]]
@@ -343,27 +315,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
+ "cpufeatures",
  "curve25519-dalek-derive",
- "digest 0.10.7",
- "fiat-crypto 0.2.9",
- "rustc_version",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "curve25519-dalek"
-version = "5.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "curve25519-dalek-derive",
- "digest 0.11.3",
- "fiat-crypto 0.3.0",
- "rand_core 0.10.1",
+ "digest",
+ "fiat-crypto",
  "rustc_version",
  "subtle",
  "zeroize",
@@ -502,20 +457,10 @@ version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "const-oid",
- "crypto-common 0.1.6",
+ "crypto-common",
  "subtle",
-]
-
-[[package]]
-name = "digest"
-version = "0.11.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f1dd6dbb5841937940781866fa1281a1ff7bd3bf827091440879f9994983d5c2"
-dependencies = [
- "block-buffer 0.12.1",
- "crypto-common 0.2.2",
 ]
 
 [[package]]
@@ -537,10 +482,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
  "der",
- "digest 0.10.7",
+ "digest",
  "elliptic-curve",
  "rfc6979",
- "signature 2.2.0",
+ "signature",
 ]
 
 [[package]]
@@ -550,16 +495,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
  "pkcs8",
- "signature 2.2.0",
-]
-
-[[package]]
-name = "ed25519"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
-dependencies = [
- "signature 3.0.0",
+ "signature",
 ]
 
 [[package]]
@@ -568,26 +504,11 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek 4.1.3",
- "ed25519 2.2.3",
- "rand_core 0.6.4",
+ "curve25519-dalek",
+ "ed25519",
+ "rand_core",
  "serde",
- "sha2 0.10.9",
- "subtle",
- "zeroize",
-]
-
-[[package]]
-name = "ed25519-dalek"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
-dependencies = [
- "curve25519-dalek 5.0.0",
- "ed25519 3.0.0",
- "rand_core 0.10.1",
- "sha2 0.11.0",
- "signature 3.0.0",
+ "sha2",
  "subtle",
  "zeroize",
 ]
@@ -606,11 +527,11 @@ checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
  "base16ct",
  "crypto-bigint",
- "digest 0.10.7",
+ "digest",
  "ff",
  "generic-array",
  "group",
- "rand_core 0.6.4",
+ "rand_core",
  "sec1",
  "subtle",
  "zeroize",
@@ -640,7 +561,7 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
 dependencies = [
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -649,12 +570,6 @@ name = "fiat-crypto"
 version = "0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
-
-[[package]]
-name = "fiat-crypto"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
 
 [[package]]
 name = "find-msvc-tools"
@@ -723,7 +638,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
 dependencies = [
  "ff",
- "rand_core 0.6.4",
+ "rand_core",
  "subtle",
 ]
 
@@ -769,16 +684,7 @@ version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
-]
-
-[[package]]
-name = "hybrid-array"
-version = "0.4.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "818356c5132c1fede50f837ca96afbe78ff42413047f4abb886217845e1b6c8c"
-dependencies = [
- "typenum",
+ "digest",
 ]
 
 [[package]]
@@ -875,7 +781,7 @@ dependencies = [
  "cfg-if",
  "ecdsa",
  "elliptic-curve",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -884,7 +790,7 @@ version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb26cec98cce3a3d96cbb7bced3c4b16e3d13f27ec56dbd62cbc8f39cfb9d653"
 dependencies = [
- "cpufeatures 0.2.17",
+ "cpufeatures",
 ]
 
 [[package]]
@@ -971,7 +877,7 @@ dependencies = [
  "ecdsa",
  "elliptic-curve",
  "primeorder",
- "sha2 0.10.9",
+ "sha2",
 ]
 
 [[package]]
@@ -1056,7 +962,7 @@ checksum = "22f6172bdec972074665ed81ed53b71da00bfc44b65a753cfde883ec4c702a1a"
 dependencies = [
  "libc",
  "rand_chacha",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1066,7 +972,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.6.4",
+ "rand_core",
 ]
 
 [[package]]
@@ -1077,12 +983,6 @@ checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom",
 ]
-
-[[package]]
-name = "rand_core"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "ref-cast"
@@ -1254,19 +1154,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
 dependencies = [
  "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.3.0",
- "digest 0.11.3",
+ "cpufeatures",
+ "digest",
 ]
 
 [[package]]
@@ -1275,7 +1164,7 @@ version = "0.10.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77fd7028345d415a4034cf8777cd4f8ab1851274233b45f84e3d955502d93874"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -1291,17 +1180,8 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
 dependencies = [
- "digest 0.10.7",
- "rand_core 0.6.4",
-]
-
-[[package]]
-name = "signature"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
-dependencies = [
- "rand_core 0.10.1",
+ "digest",
+ "rand_core",
 ]
 
 [[package]]
@@ -1374,9 +1254,9 @@ dependencies = [
  "ark-ec",
  "ark-ff",
  "ark-serialize",
- "curve25519-dalek 5.0.0",
+ "curve25519-dalek",
  "ecdsa",
- "ed25519-dalek 3.0.0",
+ "ed25519-dalek",
  "elliptic-curve",
  "generic-array",
  "getrandom",
@@ -1390,7 +1270,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "sec1",
- "sha2 0.10.9",
+ "sha2",
  "sha3",
  "soroban-builtin-sdk-macros",
  "soroban-env-common",
@@ -1439,7 +1319,7 @@ dependencies = [
  "bytes-lit",
  "ctor",
  "derive_arbitrary",
- "ed25519-dalek 2.2.0",
+ "ed25519-dalek",
  "rand",
  "rustc_version",
  "serde",
@@ -1463,7 +1343,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "sha2 0.10.9",
+ "sha2",
  "soroban-env-common",
  "soroban-spec",
  "soroban-spec-rust",
@@ -1492,7 +1372,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "sha2 0.10.9",
+ "sha2",
  "soroban-spec",
  "stellar-xdr",
  "syn 2.0.119",

--- a/contracts/src/gift/contract.rs
+++ b/contracts/src/gift/contract.rs
@@ -1,6 +1,10 @@
-use soroban_sdk::{contract, contractimpl, Address, Env};
+use soroban_sdk::{contract, contractimpl, token, Address, Env};
 
-use crate::gift::types::DataKey;
+use crate::gift::{
+    events::emit_gift_created,
+    storage::{get_gift_counter, get_token_address, set_gift, set_gift_counter},
+    types::{DataKey, Gift},
+};
 
 /// Entry point for the time-locked gift contract.
 #[contract]
@@ -8,17 +12,59 @@ pub struct GiftContract;
 
 #[contractimpl]
 impl GiftContract {
-    /// Initializes the contract with a backend admin address.
+    /// Initializes the contract with a backend admin address and the USDC
+    /// token contract address.
     ///
     /// Must be called exactly once immediately after deployment.
     /// Reverts if the admin has already been set, preventing any actor
     /// from overwriting admin rights post-deployment.
-    pub fn initialize(env: Env, admin: Address) {
+    pub fn initialize(env: Env, admin: Address, token_address: Address) {
         // Guard: panic if already initialized to prevent admin hijacking.
         if env.storage().instance().has(&DataKey::Admin) {
             panic!("already initialized");
         }
 
         env.storage().instance().set(&DataKey::Admin, &admin);
+        env.storage()
+            .instance()
+            .set(&DataKey::TokenAddress, &token_address);
+    }
+
+    /// Locks USDC from `sender` into the contract as a time-locked gift for
+    /// `recipient`, releasing after `unlock_time` (Unix timestamp in seconds).
+    ///
+    /// The transfer and record creation are atomic: if the token transfer
+    /// fails (insufficient balance, missing trustline, etc.) the entire
+    /// invocation reverts and no gift record is written.
+    ///
+    /// Returns the newly generated `gift_id`.
+    pub fn create_gift(
+        env: Env,
+        sender: Address,
+        recipient: Address,
+        amount: i128,
+        unlock_time: u64,
+    ) -> u64 {
+        sender.require_auth();
+
+        let token_address = get_token_address(&env);
+        let token_client = token::Client::new(&env, &token_address);
+        token_client.transfer(&sender, &env.current_contract_address(), &amount);
+
+        let gift_id = get_gift_counter(&env) + 1;
+        set_gift_counter(&env, gift_id);
+
+        let gift = Gift {
+            sender: sender.clone(),
+            recipient: recipient.clone(),
+            amount,
+            unlock_time,
+            is_claimed: false,
+        };
+        set_gift(&env, gift_id, &gift);
+
+        emit_gift_created(&env, gift_id, &sender, &recipient, amount, unlock_time);
+
+        gift_id
     }
 }

--- a/contracts/src/gift/events.rs
+++ b/contracts/src/gift/events.rs
@@ -2,8 +2,8 @@ use soroban_sdk::{symbol_short, Address, Env};
 
 /// Emitted when a new time-locked gift is created.
 ///
-/// Topics : ["GiftCreated", sender]
-/// Data   : (gift_id, recipient, amount, unlock_time)
+/// Topics : ["GiftCrtd", sender]
+/// Data   : (gift_id, recipient, amount, unlock_time, timestamp)
 pub fn emit_gift_created(
     env: &Env,
     gift_id: u64,
@@ -12,8 +12,68 @@ pub fn emit_gift_created(
     amount: i128,
     unlock_time: u64,
 ) {
+    let timestamp = env.ledger().timestamp();
+
     env.events().publish(
         (symbol_short!("GiftCrtd"), sender.clone()),
-        (gift_id, recipient.clone(), amount, unlock_time),
+        (gift_id, recipient.clone(), amount, unlock_time, timestamp),
     );
+}
+
+#[cfg(test)]
+mod tests {
+    use super::emit_gift_created;
+    use soroban_sdk::{
+        contract, contractimpl, symbol_short,
+        testutils::{Address as _, Events as _, Ledger as _},
+        vec, Address, Env, IntoVal,
+    };
+
+    #[contract]
+    struct EventTestContract;
+
+    #[contractimpl]
+    impl EventTestContract {
+        pub fn emit_gift_created(
+            env: Env,
+            gift_id: u64,
+            sender: Address,
+            recipient: Address,
+            amount: i128,
+            unlock_time: u64,
+        ) {
+            emit_gift_created(&env, gift_id, &sender, &recipient, amount, unlock_time);
+        }
+    }
+
+    #[test]
+    fn gift_created_uses_ledger_timestamp() {
+        let env = Env::default();
+        let contract_id = env.register(EventTestContract, ());
+        let sender = Address::generate(&env);
+        let recipient = Address::generate(&env);
+        let timestamp = 1_750_000_000u64;
+
+        env.ledger().set_timestamp(timestamp);
+
+        EventTestContractClient::new(&env, &contract_id).emit_gift_created(
+            &1,
+            &sender,
+            &recipient,
+            &5_000_000,
+            &1_760_000_000,
+        );
+
+        assert_eq!(
+            env.events().all(),
+            vec![
+                &env,
+                (
+                    contract_id,
+                    (symbol_short!("GiftCrtd"), sender).into_val(&env),
+                    (1u64, recipient, 5_000_000i128, 1_760_000_000u64, timestamp,).into_val(&env),
+                )
+            ]
+        );
+    }
 }

--- a/contracts/src/gift/mod.rs
+++ b/contracts/src/gift/mod.rs
@@ -1,5 +1,5 @@
 // Module declarations for the gift contract feature
 pub mod contract;
+pub mod events;
 pub mod storage;
 pub mod types;
-pub mod events;

--- a/contracts/src/gift/types.rs
+++ b/contracts/src/gift/types.rs
@@ -1,8 +1,30 @@
-use soroban_sdk::contracttype;
+use soroban_sdk::{contracttype, Address};
 
-/// Storage keys for the gift contract's instance storage.
+/// A time-locked gift record stored on-chain.
+#[contracttype]
+#[derive(Clone)]
+pub struct Gift {
+    /// Address that funded the gift.
+    pub sender: Address,
+    /// Address entitled to claim the gift.
+    pub recipient: Address,
+    /// USDC amount in stroops (7 decimal places).
+    pub amount: i128,
+    /// Ledger timestamp after which the gift may be claimed.
+    pub unlock_time: u64,
+    /// Whether the gift has already been claimed.
+    pub is_claimed: bool,
+}
+
+/// Storage keys for the gift contract.
 #[contracttype]
 pub enum DataKey {
     /// The privileged admin address, set once at initialization.
     Admin,
+    /// The USDC token contract address, set once at initialization.
+    TokenAddress,
+    /// Monotonically incrementing counter used to generate gift IDs.
+    GiftCounter,
+    /// Persistent record for a specific gift ID.
+    GiftRecord(u64),
 }

--- a/contracts/src/lib.rs
+++ b/contracts/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
 
+pub mod core;
 pub mod gift;
 pub mod savings;
-pub mod core;

--- a/contracts/src/savings/mod.rs
+++ b/contracts/src/savings/mod.rs
@@ -1,5 +1,5 @@
 // Module declarations for the savings contract feature
 pub mod contract;
+pub mod events;
 pub mod storage;
 pub mod types;
-pub mod events;

--- a/contracts/test_snapshots/gift/events/tests/gift_created_uses_ledger_timestamp.1.json
+++ b/contracts/test_snapshots/gift/events/tests/gift_created_uses_ledger_timestamp.1.json
@@ -1,0 +1,119 @@
+{
+  "generators": {
+    "address": 3,
+    "nonce": 0
+  },
+  "auth": [
+    [],
+    []
+  ],
+  "ledger": {
+    "protocol_version": 22,
+    "sequence_number": 0,
+    "timestamp": 1750000000,
+    "network_id": "0000000000000000000000000000000000000000000000000000000000000000",
+    "base_reserve": 0,
+    "min_persistent_entry_ttl": 4096,
+    "min_temp_entry_ttl": 16,
+    "max_entry_ttl": 6312000,
+    "ledger_entries": [
+      [
+        {
+          "contract_data": {
+            "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+            "key": "ledger_key_contract_instance",
+            "durability": "persistent"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_data": {
+                "ext": "v0",
+                "contract": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAD2KM",
+                "key": "ledger_key_contract_instance",
+                "durability": "persistent",
+                "val": {
+                  "contract_instance": {
+                    "executable": {
+                      "wasm": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+                    },
+                    "storage": null
+                  }
+                }
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ],
+      [
+        {
+          "contract_code": {
+            "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          }
+        },
+        [
+          {
+            "last_modified_ledger_seq": 0,
+            "data": {
+              "contract_code": {
+                "ext": "v0",
+                "hash": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+                "code": ""
+              }
+            },
+            "ext": "v0"
+          },
+          4095
+        ]
+      ]
+    ]
+  },
+  "events": [
+    {
+      "event": {
+        "ext": "v0",
+        "contract_id": "0000000000000000000000000000000000000000000000000000000000000001",
+        "type_": "contract",
+        "body": {
+          "v0": {
+            "topics": [
+              {
+                "symbol": "GiftCrtd"
+              },
+              {
+                "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAFCT4"
+              }
+            ],
+            "data": {
+              "vec": [
+                {
+                  "u64": 1
+                },
+                {
+                  "address": "CAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAHK3M"
+                },
+                {
+                  "i128": {
+                    "hi": 0,
+                    "lo": 5000000
+                  }
+                },
+                {
+                  "u64": 1760000000
+                },
+                {
+                  "u64": 1750000000
+                }
+              ]
+            }
+          }
+        }
+      },
+      "failed_call": false
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Add a trusted ledger timestamp to every currently emitted contract event.

The `GiftCrtd` payload now includes a timestamp sourced directly from `env.ledger().timestamp()`, so callers cannot supply or modify it. The savings module does not currently emit any events, so no savings event schema required modification.

This PR also restores the missing gift types and `create_gift` implementation from the previously merged gift feature, pins the compatible dependency version, and fixes the smart-contract CI workflow.

### Related Issue

Closes #312

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update

## How Has This Been Tested?

Added a Soroban event test that sets a known ledger timestamp, emits `GiftCrtd`, and verifies the complete event topic and payload, including the timestamp.

The following checks pass locally:

```text
cargo fmt -- --check
cargo clippy --all-targets --all-features --locked -- -D warnings
cargo test --locked
cargo build --locked --target wasm32v1-none --release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for configuring the token used by the gift contract.
  - Added time-locked gift creation, including sender, recipient, amount, unlock time, and claim status.
  - Gifts now receive unique identifiers and are recorded for later tracking.
- **Enhancements**
  - Gift creation emits an event containing the gift details and ledger timestamp.
- **Bug Fixes**
  - Improved event timestamp accuracy by using the current ledger timestamp.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->