### PR TITLE
feat: add GET /api/users/resolve — recipient lookup by phone or email

### DIFF
--- a/backend/__tests__/api/users/resolve.test.ts
+++ b/backend/__tests__/api/users/resolve.test.ts
@@ -5,7 +5,7 @@ import { getAuthPayload } from "@/lib/auth-session";
 
 jest.mock("drizzle-orm", () => ({
   eq: jest.fn(() => ({})),
-  or: jest.fn(() => ({})),
+  asc: jest.fn(() => ({})),
 }));
 
 jest.mock("@/lib/db", () => ({
@@ -25,6 +25,7 @@ jest.mock("@/lib/db/schema", () => ({
   wallets: {
     userId: "userId",
     currency: "currency",
+    createdAt: "createdAt",
   },
 }));
 
@@ -47,20 +48,32 @@ const makeEmailRequest = (email?: string) => {
   return new NextRequest(url, { method: "GET" });
 };
 
-// Build a db.select() chain that returns first call result then second call result
-const mockDbSelectChain = (firstResult: unknown[], secondResult: unknown[] = []) => {
+/**
+ * Build a db.select() chain mock.
+ *
+ * The users query chain is: select → from → where → limit
+ * The wallets query chain is: select → from → where → orderBy → limit
+ *
+ * We track call count so the first select() call returns usersResult and the
+ * second returns walletsResult.
+ */
+const mockDbSelectChain = (usersResult: unknown[], walletsResult: unknown[] = []) => {
   let callCount = 0;
-  const makeLimitMock = () =>
-    jest.fn().mockImplementation(() => {
-      callCount++;
-      return callCount === 1 ? Promise.resolve(firstResult) : Promise.resolve(secondResult);
-    });
 
-  const limitMock = makeLimitMock();
-  const whereMock = jest.fn(() => ({ limit: limitMock }));
-  const fromMock = jest.fn(() => ({ where: whereMock }));
-  const selectMock = jest.fn(() => ({ from: fromMock }));
-  (db.select as jest.Mock).mockImplementation(selectMock);
+  (db.select as jest.Mock).mockImplementation(() => {
+    callCount++;
+    const isUsersCall = callCount === 1;
+
+    const limitMock = jest.fn().mockResolvedValue(isUsersCall ? usersResult : walletsResult);
+    const orderByMock = jest.fn(() => ({ limit: limitMock }));
+    const whereMock = jest.fn(() => ({
+      limit: limitMock,      // users query doesn't call orderBy
+      orderBy: orderByMock,  // wallets query does
+    }));
+    const fromMock = jest.fn(() => ({ where: whereMock }));
+
+    return { from: fromMock };
+  });
 };
 
 describe("GET /api/users/resolve", () => {
@@ -171,7 +184,7 @@ describe("GET /api/users/resolve", () => {
     expect(json.data.avatarUrl).toBe("https://example.com/avatar.jpg");
     expect(json.data.currency).toBe("NGN");
 
-    // Masking: raw PII must not be exposed
+    // Raw PII must not be exposed
     expect(json.data.email).toBeUndefined();
     expect(json.data.phoneNumber).toBeUndefined();
     expect(json.data.passwordHash).toBeUndefined();
@@ -181,6 +194,8 @@ describe("GET /api/users/resolve", () => {
     expect(json.data.maskedEmail).not.toBe("jane@example.com");
     expect(json.data.maskedPhone).toBeDefined();
     expect(json.data.maskedPhone).not.toBe("+2348123456789");
+    // Masking must hide at least 3 chars in the middle
+    expect((json.data.maskedPhone.match(/\*/g) || []).length).toBeGreaterThanOrEqual(3);
   });
 
   // ── Successful email lookup ─────────────────────────────────────────────────
@@ -206,9 +221,27 @@ describe("GET /api/users/resolve", () => {
     expect(json.data.email).toBeUndefined();
     expect(json.data.phoneNumber).toBeUndefined();
 
-    // Masked versions present
+    // Masked email present and redacted
     expect(json.data.maskedEmail).toBeDefined();
     expect(json.data.maskedEmail).not.toBe("john@example.com");
+  });
+
+  // ── Email lookup is case-insensitive ────────────────────────────────────────
+
+  it("normalises email to lowercase before lookup", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-11", email: "s@x.com", role: "user" });
+
+    mockDbSelectChain(
+      [{ id: "ci-user", name: "Case User", avatarUrl: null, email: "ci@example.com", phoneNumber: null }],
+      [],
+    );
+
+    // Mixed-case input should resolve without error
+    const response = await GET(makeEmailRequest("CI@Example.COM"));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.id).toBe("ci-user");
   });
 
   // ── International numbers ───────────────────────────────────────────────────
@@ -228,6 +261,28 @@ describe("GET /api/users/resolve", () => {
     expect(json.data.id).toBe("uk-user");
   });
 
+  // ── Short phone masking safety ──────────────────────────────────────────────
+
+  it("always hides at least 3 chars for a short valid E.164 number", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-12", email: "s@x.com", role: "user" });
+
+    // +1234567 is 8 chars — the shortest the validator accepts
+    mockDbSelectChain(
+      [{ id: "short-phone-user", name: "Short", avatarUrl: null, email: "s@s.com", phoneNumber: "+1234567" }],
+      [],
+    );
+
+    const response = await GET(makePhoneRequest("+1234567"));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    const maskedPhone: string = json.data.maskedPhone;
+    const hiddenCount = (maskedPhone.match(/\*/g) || []).length;
+    expect(hiddenCount).toBeGreaterThanOrEqual(3);
+    // The full original number must not appear verbatim
+    expect(maskedPhone).not.toBe("+1234567");
+  });
+
   // ── No wallet ───────────────────────────────────────────────────────────────
 
   it("returns null currency when user has no wallet", async () => {
@@ -235,7 +290,7 @@ describe("GET /api/users/resolve", () => {
 
     mockDbSelectChain(
       [{ id: "no-wallet-user", name: "No Wallet", avatarUrl: null, email: "nw@example.com", phoneNumber: "+2348000000000" }],
-      [], // empty wallet result
+      [],
     );
 
     const response = await GET(makePhoneRequest("+2348000000000"));

--- a/backend/__tests__/api/users/resolve.test.ts
+++ b/backend/__tests__/api/users/resolve.test.ts
@@ -3,29 +3,34 @@ import { GET } from "@/app/api/users/resolve/route";
 import { db } from "@/lib/db";
 import { getAuthPayload } from "@/lib/auth-session";
 
+// Import schema tokens so we can assert they are passed to eq/asc calls.
+import { users, wallets } from "@/lib/db/schema";
+
+// drizzle-orm: real identity implementations so we can inspect call args.
+// eq(col, val) returns a recognisable tagged object; asc(col) likewise.
 jest.mock("drizzle-orm", () => ({
-  eq: jest.fn(() => ({})),
-  asc: jest.fn(() => ({})),
+  eq: jest.fn((col: unknown, val: unknown) => ({ __eq: { col, val } })),
+  asc: jest.fn((col: unknown) => ({ __asc: col })),
 }));
 
+import { eq, asc } from "drizzle-orm";
+
 jest.mock("@/lib/db", () => ({
-  db: {
-    select: jest.fn(),
-  },
+  db: { select: jest.fn() },
 }));
 
 jest.mock("@/lib/db/schema", () => ({
   users: {
-    id: "id",
-    name: "name",
-    avatarUrl: "avatarUrl",
-    phoneNumber: "phoneNumber",
-    email: "email",
+    id: "users.id",
+    name: "users.name",
+    avatarUrl: "users.avatarUrl",
+    phoneNumber: "users.phoneNumber",
+    email: "users.email",
   },
   wallets: {
-    userId: "userId",
-    currency: "currency",
-    createdAt: "createdAt",
+    userId: "wallets.userId",
+    currency: "wallets.currency",
+    createdAt: "wallets.createdAt",
   },
 }));
 
@@ -33,123 +38,134 @@ jest.mock("@/lib/auth-session", () => ({
   getAuthPayload: jest.fn(),
 }));
 
-// Helpers to build requests
-const makePhoneRequest = (phoneNumber?: string) => {
-  const url = phoneNumber
-    ? `http://localhost/api/users/resolve?phoneNumber=${encodeURIComponent(phoneNumber)}`
-    : "http://localhost/api/users/resolve";
-  return new NextRequest(url, { method: "GET" });
-};
+// --------------------------------------------------------------------------
+// Request helpers
+// --------------------------------------------------------------------------
+const makePhoneRequest = (phoneNumber?: string) =>
+  new NextRequest(
+    phoneNumber
+      ? `http://localhost/api/users/resolve?phoneNumber=${encodeURIComponent(phoneNumber)}`
+      : "http://localhost/api/users/resolve",
+    { method: "GET" },
+  );
 
-const makeEmailRequest = (email?: string) => {
-  const url = email
-    ? `http://localhost/api/users/resolve?email=${encodeURIComponent(email)}`
-    : "http://localhost/api/users/resolve";
-  return new NextRequest(url, { method: "GET" });
-};
+const makeEmailRequest = (email?: string) =>
+  new NextRequest(
+    email
+      ? `http://localhost/api/users/resolve?email=${encodeURIComponent(email)}`
+      : "http://localhost/api/users/resolve",
+    { method: "GET" },
+  );
 
-/**
- * Build a db.select() chain mock.
- *
- * The users query chain is: select → from → where → limit
- * The wallets query chain is: select → from → where → orderBy → limit
- *
- * We track call count so the first select() call returns usersResult and the
- * second returns walletsResult.
- */
-const mockDbSelectChain = (usersResult: unknown[], walletsResult: unknown[] = []) => {
+// --------------------------------------------------------------------------
+// Mock builder — returns captured spies for semantic assertion.
+//
+// Users chain:   select → from → where(eq) → limit
+// Wallets chain: select → from → where(eq) → orderBy(asc) → limit
+// --------------------------------------------------------------------------
+function mockDbSelectChain(usersResult: unknown[], walletsResult: unknown[] = []) {
   let callCount = 0;
+
+  const spies = {
+    usersWhere: jest.fn(),
+    walletsWhere: jest.fn(),
+    walletsOrderBy: jest.fn(),
+  };
 
   (db.select as jest.Mock).mockImplementation(() => {
     callCount++;
-    const isUsersCall = callCount === 1;
 
-    const limitMock = jest.fn().mockResolvedValue(isUsersCall ? usersResult : walletsResult);
-    const orderByMock = jest.fn(() => ({ limit: limitMock }));
-    const whereMock = jest.fn(() => ({
-      limit: limitMock,      // users query doesn't call orderBy
-      orderBy: orderByMock,  // wallets query does
-    }));
-    const fromMock = jest.fn(() => ({ where: whereMock }));
-
-    return { from: fromMock };
+    if (callCount === 1) {
+      // users query
+      const limitMock = jest.fn().mockResolvedValue(usersResult);
+      spies.usersWhere.mockReturnValue({ limit: limitMock });
+      return { from: jest.fn(() => ({ where: spies.usersWhere })) };
+    } else {
+      // wallets query
+      const limitMock = jest.fn().mockResolvedValue(walletsResult);
+      spies.walletsOrderBy.mockReturnValue({ limit: limitMock });
+      spies.walletsWhere.mockReturnValue({ orderBy: spies.walletsOrderBy });
+      return { from: jest.fn(() => ({ where: spies.walletsWhere })) };
+    }
   });
-};
 
+  return spies;
+}
+
+// --------------------------------------------------------------------------
 describe("GET /api/users/resolve", () => {
   beforeEach(() => {
     jest.clearAllMocks();
   });
 
-  // ── Authentication ──────────────────────────────────────────────────────────
+  // ── Authentication ────────────────────────────────────────────────────────
 
   it("returns 401 when no auth token is provided", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue(null);
 
-    const response = await GET(makePhoneRequest("+2348123456789"));
-    const json = await response.json();
+    const res = await GET(makePhoneRequest("+2348123456789"));
+    const json = await res.json();
 
-    expect(response.status).toBe(401);
+    expect(res.status).toBe(401);
     expect(json.detail).toBeDefined();
   });
 
-  // ── Missing / conflicting params ────────────────────────────────────────────
+  // ── Missing / conflicting params ──────────────────────────────────────────
 
   it("returns 400 when neither phoneNumber nor email is provided", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-1", email: "s@x.com", role: "user" });
 
-    const response = await GET(makePhoneRequest());
-    const json = await response.json();
+    const res = await GET(makePhoneRequest());
+    const json = await res.json();
 
-    expect(response.status).toBe(400);
+    expect(res.status).toBe(400);
     expect(json.detail).toContain("phoneNumber");
   });
 
   it("returns 400 when both phoneNumber and email are provided", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-2", email: "s@x.com", role: "user" });
 
-    const url = "http://localhost/api/users/resolve?phoneNumber=%2B2348123456789&email=jane%40example.com";
-    const response = await GET(new NextRequest(url, { method: "GET" }));
-    const json = await response.json();
+    const url =
+      "http://localhost/api/users/resolve?phoneNumber=%2B2348123456789&email=jane%40example.com";
+    const res = await GET(new NextRequest(url, { method: "GET" }));
+    const json = await res.json();
 
-    expect(response.status).toBe(400);
+    expect(res.status).toBe(400);
     expect(json.detail).toContain("only one");
   });
 
-  // ── Phone number validation ─────────────────────────────────────────────────
+  // ── Validation ────────────────────────────────────────────────────────────
 
   it("returns 400 for an invalid phone number format", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-3", email: "s@x.com", role: "user" });
 
-    const response = await GET(makePhoneRequest("not-a-phone"));
-    const json = await response.json();
+    const res = await GET(makePhoneRequest("not-a-phone"));
+    const json = await res.json();
 
-    expect(response.status).toBe(400);
+    expect(res.status).toBe(400);
     expect(json.detail).toContain("Invalid phone number");
   });
-
-  // ── Email validation ────────────────────────────────────────────────────────
 
   it("returns 400 for an invalid email format", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-4", email: "s@x.com", role: "user" });
 
-    const response = await GET(makeEmailRequest("not-an-email"));
-    const json = await response.json();
+    const res = await GET(makeEmailRequest("not-an-email"));
+    const json = await res.json();
 
-    expect(response.status).toBe(400);
+    expect(res.status).toBe(400);
     expect(json.detail).toContain("Invalid email");
   });
 
-  // ── Not found ───────────────────────────────────────────────────────────────
+  // ── Not found ─────────────────────────────────────────────────────────────
 
   it("returns 404 when no user matches the phone number", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-5", email: "s@x.com", role: "user" });
     mockDbSelectChain([]);
 
-    const response = await GET(makePhoneRequest("+2348123456789"));
-    const json = await response.json();
+    const res = await GET(makePhoneRequest("+2348123456789"));
+    const json = await res.json();
 
-    expect(response.status).toBe(404);
+    expect(res.status).toBe(404);
     expect(json.detail).toBeDefined();
   });
 
@@ -157,94 +173,148 @@ describe("GET /api/users/resolve", () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-6", email: "s@x.com", role: "user" });
     mockDbSelectChain([]);
 
-    const response = await GET(makeEmailRequest("nobody@example.com"));
-    const json = await response.json();
+    const res = await GET(makeEmailRequest("nobody@example.com"));
+    const json = await res.json();
 
-    expect(response.status).toBe(404);
+    expect(res.status).toBe(404);
     expect(json.detail).toBeDefined();
   });
 
-  // ── Successful phone lookup ─────────────────────────────────────────────────
+  // ── Phone lookup — query semantics ────────────────────────────────────────
 
-  it("returns 200 with recipient data when found by phone", async () => {
+  it("queries users.phoneNumber with the sanitised E.164 value and returns public profile", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-7", email: "s@x.com", role: "user" });
 
-    mockDbSelectChain(
-      [{ id: "recipient-uuid", name: "Jane Doe", avatarUrl: "https://example.com/avatar.jpg", email: "jane@example.com", phoneNumber: "+2348123456789" }],
+    const spies = mockDbSelectChain(
+      [
+        {
+          id: "r-uuid",
+          name: "Jane Doe",
+          avatarUrl: "https://cdn/a.jpg",
+          email: "jane@example.com",
+          phoneNumber: "+2348123456789",
+        },
+      ],
       [{ currency: "NGN" }],
     );
 
-    const response = await GET(makePhoneRequest("+2348123456789"));
-    const json = await response.json();
+    const res = await GET(makePhoneRequest("+2348123456789"));
+    const json = await res.json();
 
-    expect(response.status).toBe(200);
-    expect(json.success).toBe(true);
-    expect(json.data.id).toBe("recipient-uuid");
-    expect(json.data.name).toBe("Jane Doe");
-    expect(json.data.avatarUrl).toBe("https://example.com/avatar.jpg");
+    expect(res.status).toBe(200);
+    expect(json.data.id).toBe("r-uuid");
     expect(json.data.currency).toBe("NGN");
 
-    // Raw PII must not be exposed
+    // WHERE clause must use users.phoneNumber with the sanitised number
+    expect(spies.usersWhere).toHaveBeenCalledWith(
+      expect.objectContaining({ __eq: { col: users.phoneNumber, val: "+2348123456789" } }),
+    );
+
+    // Wallet query must be ordered by wallets.createdAt ASC
+    expect(spies.walletsOrderBy).toHaveBeenCalledWith(
+      expect.objectContaining({ __asc: wallets.createdAt }),
+    );
+
+    // Raw PII absent
     expect(json.data.email).toBeUndefined();
     expect(json.data.phoneNumber).toBeUndefined();
     expect(json.data.passwordHash).toBeUndefined();
 
-    // Masked versions should be present and redacted
-    expect(json.data.maskedEmail).toBeDefined();
+    // Masked fields present and actually masked
     expect(json.data.maskedEmail).not.toBe("jane@example.com");
-    expect(json.data.maskedPhone).toBeDefined();
     expect(json.data.maskedPhone).not.toBe("+2348123456789");
-    // Masking must hide at least 3 chars in the middle
     expect((json.data.maskedPhone.match(/\*/g) || []).length).toBeGreaterThanOrEqual(3);
   });
 
-  // ── Successful email lookup ─────────────────────────────────────────────────
+  // ── Email lookup — query semantics ────────────────────────────────────────
 
-  it("returns 200 with recipient data when found by email", async () => {
+  it("queries users.email and returns public profile", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-8", email: "s@x.com", role: "user" });
 
-    mockDbSelectChain(
-      [{ id: "recipient-uuid-2", name: "John Smith", avatarUrl: null, email: "john@example.com", phoneNumber: "+447911234567" }],
+    const spies = mockDbSelectChain(
+      [
+        {
+          id: "r-uuid-2",
+          name: "John Smith",
+          avatarUrl: null,
+          email: "john@example.com",
+          phoneNumber: "+447911234567",
+        },
+      ],
       [{ currency: "GBP" }],
     );
 
-    const response = await GET(makeEmailRequest("john@example.com"));
-    const json = await response.json();
+    const res = await GET(makeEmailRequest("john@example.com"));
+    const json = await res.json();
 
-    expect(response.status).toBe(200);
-    expect(json.success).toBe(true);
-    expect(json.data.id).toBe("recipient-uuid-2");
-    expect(json.data.name).toBe("John Smith");
+    expect(res.status).toBe(200);
+    expect(json.data.id).toBe("r-uuid-2");
     expect(json.data.currency).toBe("GBP");
 
-    // Raw PII must not be exposed
-    expect(json.data.email).toBeUndefined();
-    expect(json.data.phoneNumber).toBeUndefined();
+    // WHERE clause must use users.email
+    expect(spies.usersWhere).toHaveBeenCalledWith(
+      expect.objectContaining({ __eq: { col: users.email, val: "john@example.com" } }),
+    );
 
-    // Masked email present and redacted
-    expect(json.data.maskedEmail).toBeDefined();
+    // Raw PII absent, masked present
+    expect(json.data.email).toBeUndefined();
     expect(json.data.maskedEmail).not.toBe("john@example.com");
   });
 
-  // ── Email lookup is case-insensitive ────────────────────────────────────────
+  // ── Email normalisation — WHERE value must be lowercase ───────────────────
 
-  it("normalises email to lowercase before lookup", async () => {
+  it("passes a lowercased email to the WHERE clause regardless of input casing", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-11", email: "s@x.com", role: "user" });
 
-    mockDbSelectChain(
+    const spies = mockDbSelectChain(
       [{ id: "ci-user", name: "Case User", avatarUrl: null, email: "ci@example.com", phoneNumber: null }],
       [],
     );
 
-    // Mixed-case input should resolve without error
-    const response = await GET(makeEmailRequest("CI@Example.COM"));
-    const json = await response.json();
+    const res = await GET(makeEmailRequest("CI@Example.COM"));
+    const json = await res.json();
 
-    expect(response.status).toBe(200);
+    expect(res.status).toBe(200);
     expect(json.data.id).toBe("ci-user");
+
+    // The WHERE value must be the normalised lowercase form
+    expect(spies.usersWhere).toHaveBeenCalledWith(
+      expect.objectContaining({ __eq: { col: users.email, val: "ci@example.com" } }),
+    );
+    // The original mixed-case input must NOT have been forwarded to the DB
+    const calledVal = (spies.usersWhere as jest.Mock).mock.calls[0][0].__eq.val;
+    expect(calledVal).not.toBe("CI@Example.COM");
   });
 
-  // ── International numbers ───────────────────────────────────────────────────
+  // ── Wallet ordering ───────────────────────────────────────────────────────
+
+  it("orders wallet query by asc(createdAt) and uses the wallet.userId predicate", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-13", email: "s@x.com", role: "user" });
+
+    // Simulate user with two wallets; mock returns the earliest (NGN) first
+    const spies = mockDbSelectChain(
+      [{ id: "multi-wallet-user", name: "Multi", avatarUrl: null, email: "m@m.com", phoneNumber: "+2341234567890" }],
+      [{ currency: "NGN" }],
+    );
+
+    const res = await GET(makePhoneRequest("+2341234567890"));
+    const json = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(json.data.currency).toBe("NGN");
+
+    // orderBy must have been called with asc(wallets.createdAt)
+    expect(spies.walletsOrderBy).toHaveBeenCalledWith(
+      expect.objectContaining({ __asc: wallets.createdAt }),
+    );
+
+    // WHERE must scope to the correct recipient id
+    expect(spies.walletsWhere).toHaveBeenCalledWith(
+      expect.objectContaining({ __eq: { col: wallets.userId, val: "multi-wallet-user" } }),
+    );
+  });
+
+  // ── International numbers ─────────────────────────────────────────────────
 
   it("accepts E.164 numbers with country codes other than +234", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-9", email: "s@x.com", role: "user" });
@@ -254,36 +324,33 @@ describe("GET /api/users/resolve", () => {
       [],
     );
 
-    const response = await GET(makePhoneRequest("+447911234567"));
-    const json = await response.json();
+    const res = await GET(makePhoneRequest("+447911234567"));
+    const json = await res.json();
 
-    expect(response.status).toBe(200);
+    expect(res.status).toBe(200);
     expect(json.data.id).toBe("uk-user");
   });
 
-  // ── Short phone masking safety ──────────────────────────────────────────────
+  // ── Short phone masking safety ────────────────────────────────────────────
 
   it("always hides at least 3 chars for a short valid E.164 number", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-12", email: "s@x.com", role: "user" });
 
-    // +1234567 is 8 chars — the shortest the validator accepts
     mockDbSelectChain(
       [{ id: "short-phone-user", name: "Short", avatarUrl: null, email: "s@s.com", phoneNumber: "+1234567" }],
       [],
     );
 
-    const response = await GET(makePhoneRequest("+1234567"));
-    const json = await response.json();
+    const res = await GET(makePhoneRequest("+1234567"));
+    const json = await res.json();
 
-    expect(response.status).toBe(200);
-    const maskedPhone: string = json.data.maskedPhone;
-    const hiddenCount = (maskedPhone.match(/\*/g) || []).length;
-    expect(hiddenCount).toBeGreaterThanOrEqual(3);
-    // The full original number must not appear verbatim
-    expect(maskedPhone).not.toBe("+1234567");
+    expect(res.status).toBe(200);
+    const masked: string = json.data.maskedPhone;
+    expect((masked.match(/\*/g) || []).length).toBeGreaterThanOrEqual(3);
+    expect(masked).not.toBe("+1234567");
   });
 
-  // ── No wallet ───────────────────────────────────────────────────────────────
+  // ── No wallet ─────────────────────────────────────────────────────────────
 
   it("returns null currency when user has no wallet", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-10", email: "s@x.com", role: "user" });
@@ -293,10 +360,10 @@ describe("GET /api/users/resolve", () => {
       [],
     );
 
-    const response = await GET(makePhoneRequest("+2348000000000"));
-    const json = await response.json();
+    const res = await GET(makePhoneRequest("+2348000000000"));
+    const json = await res.json();
 
-    expect(response.status).toBe(200);
+    expect(res.status).toBe(200);
     expect(json.data.currency).toBeNull();
   });
 });

--- a/backend/__tests__/api/users/resolve.test.ts
+++ b/backend/__tests__/api/users/resolve.test.ts
@@ -5,6 +5,7 @@ import { getAuthPayload } from "@/lib/auth-session";
 
 jest.mock("drizzle-orm", () => ({
   eq: jest.fn(() => ({})),
+  or: jest.fn(() => ({})),
 }));
 
 jest.mock("@/lib/db", () => ({
@@ -19,6 +20,11 @@ jest.mock("@/lib/db/schema", () => ({
     name: "name",
     avatarUrl: "avatarUrl",
     phoneNumber: "phoneNumber",
+    email: "email",
+  },
+  wallets: {
+    userId: "userId",
+    currency: "currency",
   },
 }));
 
@@ -26,12 +32,35 @@ jest.mock("@/lib/auth-session", () => ({
   getAuthPayload: jest.fn(),
 }));
 
-// Silence rate-limiter state leak between tests by resetting per unique key
-const makeRequest = (phoneNumber?: string) => {
+// Helpers to build requests
+const makePhoneRequest = (phoneNumber?: string) => {
   const url = phoneNumber
     ? `http://localhost/api/users/resolve?phoneNumber=${encodeURIComponent(phoneNumber)}`
     : "http://localhost/api/users/resolve";
   return new NextRequest(url, { method: "GET" });
+};
+
+const makeEmailRequest = (email?: string) => {
+  const url = email
+    ? `http://localhost/api/users/resolve?email=${encodeURIComponent(email)}`
+    : "http://localhost/api/users/resolve";
+  return new NextRequest(url, { method: "GET" });
+};
+
+// Build a db.select() chain that returns first call result then second call result
+const mockDbSelectChain = (firstResult: unknown[], secondResult: unknown[] = []) => {
+  let callCount = 0;
+  const makeLimitMock = () =>
+    jest.fn().mockImplementation(() => {
+      callCount++;
+      return callCount === 1 ? Promise.resolve(firstResult) : Promise.resolve(secondResult);
+    });
+
+  const limitMock = makeLimitMock();
+  const whereMock = jest.fn(() => ({ limit: limitMock }));
+  const fromMock = jest.fn(() => ({ where: whereMock }));
+  const selectMock = jest.fn(() => ({ from: fromMock }));
+  (db.select as jest.Mock).mockImplementation(selectMock);
 };
 
 describe("GET /api/users/resolve", () => {
@@ -39,85 +68,100 @@ describe("GET /api/users/resolve", () => {
     jest.clearAllMocks();
   });
 
+  // ── Authentication ──────────────────────────────────────────────────────────
+
   it("returns 401 when no auth token is provided", async () => {
     (getAuthPayload as jest.Mock).mockResolvedValue(null);
 
-    const response = await GET(makeRequest("+2348123456789"));
+    const response = await GET(makePhoneRequest("+2348123456789"));
     const json = await response.json();
 
     expect(response.status).toBe(401);
     expect(json.detail).toBeDefined();
   });
 
-  it("returns 400 when phoneNumber query param is missing", async () => {
-    (getAuthPayload as jest.Mock).mockResolvedValue({
-      userId: "sender-1",
-      email: "sender@example.com",
-      role: "Sender",
-    });
+  // ── Missing / conflicting params ────────────────────────────────────────────
 
-    const response = await GET(makeRequest());
+  it("returns 400 when neither phoneNumber nor email is provided", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-1", email: "s@x.com", role: "user" });
+
+    const response = await GET(makePhoneRequest());
     const json = await response.json();
 
     expect(response.status).toBe(400);
     expect(json.detail).toContain("phoneNumber");
   });
 
-  it("returns 400 for an invalid phone number format", async () => {
-    (getAuthPayload as jest.Mock).mockResolvedValue({
-      userId: "sender-2",
-      email: "sender@example.com",
-      role: "Sender",
-    });
+  it("returns 400 when both phoneNumber and email are provided", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-2", email: "s@x.com", role: "user" });
 
-    const response = await GET(makeRequest("not-a-phone"));
+    const url = "http://localhost/api/users/resolve?phoneNumber=%2B2348123456789&email=jane%40example.com";
+    const response = await GET(new NextRequest(url, { method: "GET" }));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.detail).toContain("only one");
+  });
+
+  // ── Phone number validation ─────────────────────────────────────────────────
+
+  it("returns 400 for an invalid phone number format", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-3", email: "s@x.com", role: "user" });
+
+    const response = await GET(makePhoneRequest("not-a-phone"));
     const json = await response.json();
 
     expect(response.status).toBe(400);
     expect(json.detail).toContain("Invalid phone number");
   });
 
+  // ── Email validation ────────────────────────────────────────────────────────
+
+  it("returns 400 for an invalid email format", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-4", email: "s@x.com", role: "user" });
+
+    const response = await GET(makeEmailRequest("not-an-email"));
+    const json = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(json.detail).toContain("Invalid email");
+  });
+
+  // ── Not found ───────────────────────────────────────────────────────────────
+
   it("returns 404 when no user matches the phone number", async () => {
-    (getAuthPayload as jest.Mock).mockResolvedValue({
-      userId: "sender-3",
-      email: "sender@example.com",
-      role: "Sender",
-    });
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-5", email: "s@x.com", role: "user" });
+    mockDbSelectChain([]);
 
-    // Simulate empty DB result
-    const limitMock = jest.fn().mockResolvedValue([]);
-    const whereMock = jest.fn(() => ({ limit: limitMock }));
-    const fromMock = jest.fn(() => ({ where: whereMock }));
-    const selectMock = jest.fn(() => ({ from: fromMock }));
-    (db.select as jest.Mock).mockImplementation(selectMock);
-
-    const response = await GET(makeRequest("+2348123456789"));
+    const response = await GET(makePhoneRequest("+2348123456789"));
     const json = await response.json();
 
     expect(response.status).toBe(404);
     expect(json.detail).toBeDefined();
   });
 
-  it("returns 200 with recipient data when found", async () => {
-    (getAuthPayload as jest.Mock).mockResolvedValue({
-      userId: "sender-4",
-      email: "sender@example.com",
-      role: "Sender",
-    });
+  it("returns 404 when no user matches the email", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-6", email: "s@x.com", role: "user" });
+    mockDbSelectChain([]);
 
-    const limitMock = jest.fn().mockResolvedValue([
-      {
-        id: "recipient-uuid",
-        name: "Jane Doe",
-        avatarUrl: "https://example.com/avatar.jpg",
-      },
-    ]);
-    const whereMock = jest.fn(() => ({ limit: limitMock }));
-    const fromMock = jest.fn(() => ({ where: whereMock }));
-    const selectMock = jest.fn(() => ({ from: fromMock }));
-    (db.select as jest.Mock).mockImplementation(selectMock);
+    const response = await GET(makeEmailRequest("nobody@example.com"));
+    const json = await response.json();
 
-    const response = await GET(makeRequest("+2348123456789"));
+    expect(response.status).toBe(404);
+    expect(json.detail).toBeDefined();
+  });
+
+  // ── Successful phone lookup ─────────────────────────────────────────────────
+
+  it("returns 200 with recipient data when found by phone", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-7", email: "s@x.com", role: "user" });
+
+    mockDbSelectChain(
+      [{ id: "recipient-uuid", name: "Jane Doe", avatarUrl: "https://example.com/avatar.jpg", email: "jane@example.com", phoneNumber: "+2348123456789" }],
+      [{ currency: "NGN" }],
+    );
+
+    const response = await GET(makePhoneRequest("+2348123456789"));
     const json = await response.json();
 
     expect(response.status).toBe(200);
@@ -125,31 +169,79 @@ describe("GET /api/users/resolve", () => {
     expect(json.data.id).toBe("recipient-uuid");
     expect(json.data.name).toBe("Jane Doe");
     expect(json.data.avatarUrl).toBe("https://example.com/avatar.jpg");
-    // Sensitive fields must not be present
+    expect(json.data.currency).toBe("NGN");
+
+    // Masking: raw PII must not be exposed
     expect(json.data.email).toBeUndefined();
     expect(json.data.phoneNumber).toBeUndefined();
     expect(json.data.passwordHash).toBeUndefined();
+
+    // Masked versions should be present and redacted
+    expect(json.data.maskedEmail).toBeDefined();
+    expect(json.data.maskedEmail).not.toBe("jane@example.com");
+    expect(json.data.maskedPhone).toBeDefined();
+    expect(json.data.maskedPhone).not.toBe("+2348123456789");
   });
 
+  // ── Successful email lookup ─────────────────────────────────────────────────
+
+  it("returns 200 with recipient data when found by email", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-8", email: "s@x.com", role: "user" });
+
+    mockDbSelectChain(
+      [{ id: "recipient-uuid-2", name: "John Smith", avatarUrl: null, email: "john@example.com", phoneNumber: "+447911234567" }],
+      [{ currency: "GBP" }],
+    );
+
+    const response = await GET(makeEmailRequest("john@example.com"));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.success).toBe(true);
+    expect(json.data.id).toBe("recipient-uuid-2");
+    expect(json.data.name).toBe("John Smith");
+    expect(json.data.currency).toBe("GBP");
+
+    // Raw PII must not be exposed
+    expect(json.data.email).toBeUndefined();
+    expect(json.data.phoneNumber).toBeUndefined();
+
+    // Masked versions present
+    expect(json.data.maskedEmail).toBeDefined();
+    expect(json.data.maskedEmail).not.toBe("john@example.com");
+  });
+
+  // ── International numbers ───────────────────────────────────────────────────
+
   it("accepts E.164 numbers with country codes other than +234", async () => {
-    (getAuthPayload as jest.Mock).mockResolvedValue({
-      userId: "sender-5",
-      email: "sender@example.com",
-      role: "Sender",
-    });
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-9", email: "s@x.com", role: "user" });
 
-    const limitMock = jest.fn().mockResolvedValue([
-      { id: "uk-user", name: "John Smith", avatarUrl: null },
-    ]);
-    const whereMock = jest.fn(() => ({ limit: limitMock }));
-    const fromMock = jest.fn(() => ({ where: whereMock }));
-    const selectMock = jest.fn(() => ({ from: fromMock }));
-    (db.select as jest.Mock).mockImplementation(selectMock);
+    mockDbSelectChain(
+      [{ id: "uk-user", name: "John Smith", avatarUrl: null, email: "js@uk.com", phoneNumber: "+447911234567" }],
+      [],
+    );
 
-    const response = await GET(makeRequest("+447911234567"));
+    const response = await GET(makePhoneRequest("+447911234567"));
     const json = await response.json();
 
     expect(response.status).toBe(200);
     expect(json.data.id).toBe("uk-user");
+  });
+
+  // ── No wallet ───────────────────────────────────────────────────────────────
+
+  it("returns null currency when user has no wallet", async () => {
+    (getAuthPayload as jest.Mock).mockResolvedValue({ userId: "s-10", email: "s@x.com", role: "user" });
+
+    mockDbSelectChain(
+      [{ id: "no-wallet-user", name: "No Wallet", avatarUrl: null, email: "nw@example.com", phoneNumber: "+2348000000000" }],
+      [], // empty wallet result
+    );
+
+    const response = await GET(makePhoneRequest("+2348000000000"));
+    const json = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(json.data.currency).toBeNull();
   });
 });

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,6 +33,11 @@
     "stripe": "^20.2.0",
     "zod": "^4.3.6"
   },
+  "pnpm": {
+    "overrides": {
+      "jest-mock": "^30.0.0"
+    }
+  },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@types/bcryptjs": "^2.4.6",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,11 +33,6 @@
     "stripe": "^20.2.0",
     "zod": "^4.3.6"
   },
-  "pnpm": {
-    "overrides": {
-      "jest-mock": "^30.0.0"
-    }
-  },
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@types/bcryptjs": "^2.4.6",

--- a/backend/src/api/users/resolve/route.ts
+++ b/backend/src/api/users/resolve/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq, or } from "drizzle-orm";
+import { asc, eq } from "drizzle-orm";
 
 import { db } from "@/lib/db";
 import { users, wallets } from "@/lib/db/schema";
@@ -18,7 +18,7 @@ import { consumeRateLimit } from "@/lib/rate-limiter";
 const RESOLVE_RATE_LIMIT = 20;
 const RESOLVE_RATE_WINDOW_MS = 60_000;
 
-/** Mask an email: "john.doe@example.com" → "jo**@example.com" */
+/** Mask an email: "john.doe@example.com" → "jo***@example.com" */
 function maskEmail(email: string): string {
   const [local, domain] = email.split("@");
   if (!domain) return "***";
@@ -26,13 +26,38 @@ function maskEmail(email: string): string {
   return `${visible}***@${domain}`;
 }
 
-/** Mask a phone number: "+2348123456789" → "+234*****6789" */
+/**
+ * Mask a phone number safely: "+2348123456789" → "+234*****6789"
+ *
+ * We show at most the first 4 chars (country-code prefix) and the last 4 digits.
+ * The two visible windows are clamped so they never overlap — for short but
+ * valid E.164 numbers the prefix is shortened and/or the suffix is omitted to
+ * guarantee at least 3 hidden characters in the middle.
+ */
 function maskPhone(phone: string): string {
-  if (phone.length <= 6) return "***";
-  const prefix = phone.slice(0, phone.startsWith("+") ? 4 : 3);
-  const last4 = phone.slice(-4);
-  const hidden = "*".repeat(Math.max(phone.length - prefix.length - 4, 3));
-  return `${prefix}${hidden}${last4}`;
+  const len = phone.length;
+  if (len <= 6) return "***";
+
+  // How many chars we want to show at the start (country code hint)
+  const wantPrefix = phone.startsWith("+") ? 4 : 3;
+  // How many chars we want to show at the end (last-4 confirmation)
+  const wantSuffix = 4;
+  // Minimum hidden chars to guarantee real obfuscation
+  const minHidden = 3;
+
+  // Total budget: we must hide at least minHidden chars
+  const maxVisible = len - minHidden;
+
+  // Clamp prefix + suffix to the available budget, prefix takes priority
+  const actualPrefix = Math.min(wantPrefix, maxVisible);
+  const actualSuffix = Math.min(wantSuffix, Math.max(0, maxVisible - actualPrefix));
+
+  const prefix = phone.slice(0, actualPrefix);
+  const suffix = actualSuffix > 0 ? phone.slice(len - actualSuffix) : "";
+  const hiddenCount = len - actualPrefix - actualSuffix;
+  const hidden = "*".repeat(hiddenCount);
+
+  return `${prefix}${hidden}${suffix}`;
 }
 
 export async function GET(request: NextRequest) {
@@ -115,6 +140,9 @@ export async function GET(request: NextRequest) {
           "Invalid email address format.",
         );
       }
+      // Normalise to lowercase so lookup matches regardless of how the address
+      // was stored (defensive — registration should also lowercase, but this
+      // ensures resolution never silently fails due to case drift).
       whereCondition = eq(users.email, trimmed.toLowerCase());
       lookupType = "email";
     }
@@ -146,10 +174,13 @@ export async function GET(request: NextRequest) {
     // We intentionally allow it so the sender can confirm their own profile renders correctly.
 
     // --- Fetch the recipient's primary wallet currency ---
+    // Order by createdAt ASC so we always pick the earliest (primary) wallet
+    // deterministically — a user may hold multiple currency wallets.
     const walletRows = await db
       .select({ currency: wallets.currency })
       .from(wallets)
       .where(eq(wallets.userId, recipient.id))
+      .orderBy(asc(wallets.createdAt))
       .limit(1);
 
     const currency = walletRows[0]?.currency ?? null;

--- a/backend/src/api/users/resolve/route.ts
+++ b/backend/src/api/users/resolve/route.ts
@@ -1,17 +1,39 @@
 import { NextRequest, NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { eq, or } from "drizzle-orm";
 
 import { db } from "@/lib/db";
-import { users } from "@/lib/db/schema";
+import { users, wallets } from "@/lib/db/schema";
 import { getAuthPayload } from "@/lib/auth-session";
 import { createProblemDetails } from "@/lib/api-utils";
-import { sanitizePhoneNumber, validateE164PhoneNumber } from "@/lib/validation";
+import {
+  sanitizeInput,
+  sanitizePhoneNumber,
+  validateE164PhoneNumber,
+  validateEmail,
+} from "@/lib/validation";
 import { consumeRateLimit } from "@/lib/rate-limiter";
 
 // 20 lookups per minute per authenticated user — enough for legitimate use,
-// tight enough to prevent phone-number enumeration.
+// tight enough to prevent phone-number / email enumeration.
 const RESOLVE_RATE_LIMIT = 20;
 const RESOLVE_RATE_WINDOW_MS = 60_000;
+
+/** Mask an email: "john.doe@example.com" → "jo**@example.com" */
+function maskEmail(email: string): string {
+  const [local, domain] = email.split("@");
+  if (!domain) return "***";
+  const visible = local.slice(0, Math.min(2, local.length));
+  return `${visible}***@${domain}`;
+}
+
+/** Mask a phone number: "+2348123456789" → "+234*****6789" */
+function maskPhone(phone: string): string {
+  if (phone.length <= 6) return "***";
+  const prefix = phone.slice(0, phone.startsWith("+") ? 4 : 3);
+  const last4 = phone.slice(-4);
+  const hidden = "*".repeat(Math.max(phone.length - prefix.length - 4, 3));
+  return `${prefix}${hidden}${last4}`;
+}
 
 export async function GET(request: NextRequest) {
   try {
@@ -41,29 +63,61 @@ export async function GET(request: NextRequest) {
       );
     }
 
-    // --- Input validation ---
+    // --- Input extraction ---
     const { searchParams } = new URL(request.url);
     const rawPhone = searchParams.get("phoneNumber");
+    const rawEmail = searchParams.get("email");
 
-    if (!rawPhone || rawPhone.trim() === "") {
+    // Exactly one of phoneNumber or email must be provided
+    if (!rawPhone && !rawEmail) {
       return createProblemDetails(
         "about:blank",
         "Bad Request",
         400,
-        "Query parameter 'phoneNumber' is required.",
+        "Provide either a 'phoneNumber' or 'email' query parameter.",
       );
     }
 
-    if (!validateE164PhoneNumber(rawPhone)) {
+    if (rawPhone && rawEmail) {
       return createProblemDetails(
         "about:blank",
         "Bad Request",
         400,
-        "Invalid phone number format. Use E.164 format (e.g. +2348123456789).",
+        "Provide only one of 'phoneNumber' or 'email', not both.",
       );
     }
 
-    const sanitizedPhone = sanitizePhoneNumber(rawPhone);
+    // --- Validate & normalise the input ---
+    let whereCondition;
+    let lookupType: "phone" | "email";
+
+    if (rawPhone) {
+      const trimmed = sanitizeInput(rawPhone);
+      if (!validateE164PhoneNumber(trimmed)) {
+        return createProblemDetails(
+          "about:blank",
+          "Bad Request",
+          400,
+          "Invalid phone number format. Use E.164 format (e.g. +2348123456789).",
+        );
+      }
+      const sanitizedPhone = sanitizePhoneNumber(trimmed);
+      whereCondition = eq(users.phoneNumber, sanitizedPhone);
+      lookupType = "phone";
+    } else {
+      // rawEmail is guaranteed non-null here
+      const trimmed = sanitizeInput(rawEmail as string);
+      if (!validateEmail(trimmed)) {
+        return createProblemDetails(
+          "about:blank",
+          "Bad Request",
+          400,
+          "Invalid email address format.",
+        );
+      }
+      whereCondition = eq(users.email, trimmed.toLowerCase());
+      lookupType = "email";
+    }
 
     // --- Database lookup ---
     const recipientRows = await db
@@ -71,21 +125,38 @@ export async function GET(request: NextRequest) {
         id: users.id,
         name: users.name,
         avatarUrl: users.avatarUrl,
+        email: users.email,
+        phoneNumber: users.phoneNumber,
       })
       .from(users)
-      .where(eq(users.phoneNumber, sanitizedPhone))
+      .where(whereCondition)
       .limit(1);
 
     const recipient = recipientRows[0];
 
     if (!recipient) {
-      return createProblemDetails(
-        "about:blank",
-        "Not Found",
-        404,
-        "No account found with the provided phone number.",
-      );
+      const notFoundDetail =
+        lookupType === "phone"
+          ? "No account found with the provided phone number."
+          : "No account found with the provided email address.";
+      return createProblemDetails("about:blank", "Not Found", 404, notFoundDetail);
     }
+
+    // Prevent a sender from looking themselves up (optional guard — harmless but clean)
+    // We intentionally allow it so the sender can confirm their own profile renders correctly.
+
+    // --- Fetch the recipient's primary wallet currency ---
+    const walletRows = await db
+      .select({ currency: wallets.currency })
+      .from(wallets)
+      .where(eq(wallets.userId, recipient.id))
+      .limit(1);
+
+    const currency = walletRows[0]?.currency ?? null;
+
+    // --- Build sanitised public profile (no raw PII) ---
+    const maskedEmail = recipient.email ? maskEmail(recipient.email) : null;
+    const maskedPhone = recipient.phoneNumber ? maskPhone(recipient.phoneNumber) : null;
 
     return NextResponse.json(
       {
@@ -94,6 +165,9 @@ export async function GET(request: NextRequest) {
           id: recipient.id,
           name: recipient.name,
           avatarUrl: recipient.avatarUrl,
+          maskedEmail,
+          maskedPhone,
+          currency,
         },
       },
       { status: 200 },

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -47,6 +47,8 @@ import { GET as dashboardGiftsGet } from "./api/dashboard/gifts/route";
 // Gifts
 import { POST as giftRedeemPost } from "./api/gifts/redeem/route";
 import { POST as giftAppreciatePost } from "./api/gifts/appreciate/route";
+// Users
+import { GET as resolveRecipientGet } from "./api/users/resolve/route";
 import { POST as forgotPasswordPost } from "./api/auth/forgot-password/route";
 import { POST as loginPost } from "./api/auth/login/route";
 import { POST as logoutPost } from "./api/auth/logout/route";
@@ -86,7 +88,16 @@ apiRouter.post("/api/auth/send-verification", makeExpressHandler(sendVerificatio
 apiRouter.post("/api/auth/verify-email", makeExpressHandler(verifyEmailPost));
 apiRouter.post("/api/auth/verify-otp", makeExpressHandler(verifyOtpPost));
 
-// 2. Upload routes
+// 2. Dashboard routes
+apiRouter.get("/api/dashboard/stats", makeExpressHandler(dashboardStatsGet));
+apiRouter.get("/api/dashboard/gifts", makeExpressHandler(dashboardGiftsGet));
+
+// 3. Gifts routes
+apiRouter.post("/api/gifts/redeem", makeExpressHandler(giftRedeemPost));
+apiRouter.post("/api/gifts/appreciate", makeExpressHandler(giftAppreciatePost));
+
+// 4. Upload routes
 apiRouter.post("/api/upload/image", limitUploadSize, makeExpressHandler(uploadImagePost));
 
-
+// 5. Users routes
+apiRouter.get("/api/users/resolve", makeExpressHandler(resolveRecipientGet));

--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "zendvo-monorepo",
   "private": true,
   "scripts": {
+    "postinstall": "node scripts/patch-jest-mock.js",
     "dev:web": "pnpm --filter web run dev",
     "dev:backend": "pnpm --filter backend run dev",
     "dev": "concurrently \"pnpm run dev:web\" \"pnpm run dev:backend\"",
@@ -14,11 +15,6 @@
     "db:migrate": "pnpm --filter backend run db:migrate",
     "db:push": "pnpm --filter backend run db:push",
     "db:check": "pnpm --filter backend run db:check"
-  },
-  "pnpm": {
-    "overrides": {
-      "jest-mock": "^30.0.0"
-    }
   },
   "devDependencies": {
     "@types/node-cron": "^3.0.11",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,11 @@
     "db:push": "pnpm --filter backend run db:push",
     "db:check": "pnpm --filter backend run db:check"
   },
+  "pnpm": {
+    "overrides": {
+      "jest-mock": "^30.0.0"
+    }
+  },
   "devDependencies": {
     "@types/node-cron": "^3.0.11",
     "concurrently": "^8.2.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,6 +4,9 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
+overrides:
+  jest-mock: ^30.0.0
+
 importers:
 
   .:
@@ -1034,105 +1037,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1425,28 +1412,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.2':
     resolution: {integrity: sha512-Sn6LxPIZcADe5AnqqMCfwBv6vRtDikhtrjwhu+19WM6jHZe31JDRcGuPZAlJrDk6aEbNBPUUAKmySJELkBOesg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.2':
     resolution: {integrity: sha512-nwzesEQBfQIOOnQ7JArzB08w9qwvBQ7nC1i8gb0tiEFH94apzQM3IRpY19MlE8RBHxc9ArG26t1DEg2aaLaqVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.2':
     resolution: {integrity: sha512-s60bLf16BDoICQHeKEm0lDgUNMsL1UpQCkRNZk08ZNnRpK0QUV+6TvVHuBcIA7oItzU0m7kVmXe8QjXngYxJVA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.2':
     resolution: {integrity: sha512-Sq8k4SZd8Y8EokKdz304TvMO9HoiwGzo0CTacaiN1bBtbJSQ1BIwKzNFeFdxOe93SHn1YGnKXG6Mq3N+tVooyQ==}
@@ -1603,28 +1586,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -1913,61 +1892,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -3526,10 +3495,6 @@ packages:
     resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
-  jest-mock@29.7.0:
-    resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
-    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
-
   jest-mock@30.4.1:
     resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -3737,7 +3702,6 @@ packages:
 
   libsql@0.5.29:
     resolution: {integrity: sha512-8lMP8iMgiBzzoNbAPQ59qdVcj6UaE/Vnm+fiwX4doX4Narook0a4GPKWBEv+CR8a1OwbfkgL18uBfBjWdF0Fzg==}
-    cpu: [x64, arm64, wasm32, arm]
     os: [darwin, linux, win32]
 
   lightningcss-android-arm64@1.32.0:
@@ -3775,28 +3739,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5898,7 +5858,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.43
-      jest-mock: 29.7.0
+      jest-mock: 30.4.1
 
   '@jest/environment@30.4.1':
     dependencies:
@@ -5935,7 +5895,7 @@ snapshots:
       '@sinonjs/fake-timers': 10.3.0
       '@types/node': 20.19.43
       jest-message-util: 29.7.0
-      jest-mock: 29.7.0
+      jest-mock: 30.4.1
       jest-util: 29.7.0
 
   '@jest/fake-timers@30.4.1':
@@ -5954,7 +5914,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/expect': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
-      jest-mock: 29.7.0
+      jest-mock: 30.4.1
     transitivePeerDependencies:
       - supports-color
 
@@ -8654,7 +8614,7 @@ snapshots:
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
       '@types/node': 20.19.43
-      jest-mock: 29.7.0
+      jest-mock: 30.4.1
       jest-util: 29.7.0
       jsdom: 20.0.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -8668,7 +8628,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.43
-      jest-mock: 29.7.0
+      jest-mock: 30.4.1
       jest-util: 29.7.0
 
   jest-environment-node@30.4.1:
@@ -8762,12 +8722,6 @@ snapshots:
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
-
-  jest-mock@29.7.0:
-    dependencies:
-      '@jest/types': 29.6.3
-      '@types/node': 20.19.43
-      jest-util: 29.7.0
 
   jest-mock@30.4.1:
     dependencies:
@@ -8894,7 +8848,7 @@ snapshots:
       graceful-fs: 4.2.11
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
-      jest-mock: 29.7.0
+      jest-mock: 30.4.1
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
       jest-snapshot: 29.7.0(supports-color@8.1.1)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -4,9 +4,6 @@ settings:
   autoInstallPeers: true
   excludeLinksFromLockfile: false
 
-overrides:
-  jest-mock: ^30.0.0
-
 importers:
 
   .:
@@ -3495,6 +3492,10 @@ packages:
     resolution: {integrity: sha512-kwCKIvq0MCW1HzLoGola9Te6JUdzgV0loyKJ3Qghrkz9i5/RRIHsL95BMQc2HBBhlBKC4j22K9p11TGHH8RBpQ==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
 
+  jest-mock@29.7.0:
+    resolution: {integrity: sha512-ITOMZn+UkYS4ZFh83xYAOzWStloNzJFO2s8DWrE4lhtGD+AorgnbkiKERe4wQVBydIGPx059g6riW5Btp6Llnw==}
+    engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
+
   jest-mock@30.4.1:
     resolution: {integrity: sha512-/i8SVb8/NSB7RfNi8gfqu8gxLV23KaL5EpAttyb9iz8qWRIqXRLflycz/32wXsYkOnaUlx8NAKnJYtpsmXUmfw==}
     engines: {node: ^18.14.0 || ^20.0.0 || ^22.0.0 || >=24.0.0}
@@ -5858,7 +5859,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.43
-      jest-mock: 30.4.1
+      jest-mock: 29.7.0
 
   '@jest/environment@30.4.1':
     dependencies:
@@ -5895,7 +5896,7 @@ snapshots:
       '@sinonjs/fake-timers': 10.3.0
       '@types/node': 20.19.43
       jest-message-util: 29.7.0
-      jest-mock: 30.4.1
+      jest-mock: 29.7.0
       jest-util: 29.7.0
 
   '@jest/fake-timers@30.4.1':
@@ -5914,7 +5915,7 @@ snapshots:
       '@jest/environment': 29.7.0
       '@jest/expect': 29.7.0(supports-color@8.1.1)
       '@jest/types': 29.6.3
-      jest-mock: 30.4.1
+      jest-mock: 29.7.0
     transitivePeerDependencies:
       - supports-color
 
@@ -8614,7 +8615,7 @@ snapshots:
       '@jest/types': 29.6.3
       '@types/jsdom': 20.0.1
       '@types/node': 20.19.43
-      jest-mock: 30.4.1
+      jest-mock: 29.7.0
       jest-util: 29.7.0
       jsdom: 20.0.3(supports-color@8.1.1)
     transitivePeerDependencies:
@@ -8628,7 +8629,7 @@ snapshots:
       '@jest/fake-timers': 29.7.0
       '@jest/types': 29.6.3
       '@types/node': 20.19.43
-      jest-mock: 30.4.1
+      jest-mock: 29.7.0
       jest-util: 29.7.0
 
   jest-environment-node@30.4.1:
@@ -8722,6 +8723,12 @@ snapshots:
       pretty-format: 30.4.1
       slash: 3.0.0
       stack-utils: 2.0.6
+
+  jest-mock@29.7.0:
+    dependencies:
+      '@jest/types': 29.6.3
+      '@types/node': 20.19.43
+      jest-util: 29.7.0
 
   jest-mock@30.4.1:
     dependencies:
@@ -8848,7 +8855,7 @@ snapshots:
       graceful-fs: 4.2.11
       jest-haste-map: 29.7.0
       jest-message-util: 29.7.0
-      jest-mock: 30.4.1
+      jest-mock: 29.7.0
       jest-regex-util: 29.6.3
       jest-resolve: 29.7.0
       jest-snapshot: 29.7.0(supports-color@8.1.1)

--- a/scripts/patch-jest-mock.js
+++ b/scripts/patch-jest-mock.js
@@ -1,0 +1,56 @@
+/**
+ * patch-jest-mock.js
+ *
+ * Polyfills `clearMocksOnScope` into jest-mock@29 so it is compatible with
+ * jest-runtime@30, which calls this._moduleMocker.clearMocksOnScope(scope)
+ * during module reset.
+ *
+ * This patch is idempotent — it is safe to run multiple times.
+ * It runs automatically via the root package.json `postinstall` script.
+ */
+
+const fs = require("fs");
+const path = require("path");
+
+const JEST_MOCK_29_PATH = path.resolve(
+  __dirname,
+  "../node_modules/.pnpm/jest-mock@29.7.0/node_modules/jest-mock/build/index.js",
+);
+
+if (!fs.existsSync(JEST_MOCK_29_PATH)) {
+  console.log("[patch-jest-mock] jest-mock@29 not found, skipping patch.");
+  process.exit(0);
+}
+
+const src = fs.readFileSync(JEST_MOCK_29_PATH, "utf8");
+
+if (src.includes("clearMocksOnScope")) {
+  console.log("[patch-jest-mock] Already patched, nothing to do.");
+  process.exit(0);
+}
+
+const PATCH = `  clearMocksOnScope(scope) {
+    for (const key of Object.keys(scope)) {
+      const value = scope[key];
+      if (
+        value != null &&
+        (typeof value === 'object' || typeof value === 'function') &&
+        '_isMockFunction' in value &&
+        this.isMockFunction(value) &&
+        typeof value.mockClear === 'function'
+      ) {
+        value.mockClear();
+      }
+    }
+  }
+`;
+
+const patched = src.replace("  clearAllMocks() {", PATCH + "  clearAllMocks() {");
+
+if (patched === src) {
+  console.error("[patch-jest-mock] Could not find insertion point. Skipping.");
+  process.exit(0);
+}
+
+fs.writeFileSync(JEST_MOCK_29_PATH, patched, "utf8");
+console.log("[patch-jest-mock] jest-mock@29 patched successfully.");


### PR DESCRIPTION
## Summary

Implements issue #330 — a backend endpoint that lets the "Send a Gift" UI look up a recipient's public profile by phone number or email before the sender confirms.

## Changes

### `backend/src/api/users/resolve/route.ts`
- Accepts `?phoneNumber=` (E.164 format) **or** `?email=` as mutually exclusive query params
- Validates input with the existing `validateE164PhoneNumber` / `validateEmail` helpers
- Queries the `users` table via Drizzle ORM; fetches the recipient's primary wallet for currency
- Returns a sanitised public profile — **no raw PII is ever exposed**:
  ```json
  {
    "success": true,
    "data": {
      "id": "uuid",
      "name": "Jane Doe",
      "avatarUrl": "https://…",
      "maskedEmail": "ja***@example.com",
      "maskedPhone": "+234*****6789",
      "currency": "NGN"
    }
  }
  ```
- Rate-limited to **20 requests / minute per authenticated user** to prevent phone/email enumeration

### `backend/src/routes.ts`
- Registers `GET /api/users/resolve`

### `backend/__tests__/api/users/resolve.test.ts`
- 11 unit tests covering: unauthenticated, missing params, conflicting params, invalid phone, invalid email, 404 by phone, 404 by email, 200 by phone, 200 by email, international numbers, null currency

### `package.json` (root + backend)
- Added `pnpm.overrides.jest-mock: "^30.0.0"` to fix a pre-existing ts-jest 29 / Jest 30 incompatibility that was silently breaking the entire test suite

## Testing

```
pnpm --filter backend test -- --testPathPatterns="users/resolve"
```

All 11 tests pass ✅

## Closes

Closes #330

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a protected recipient-resolving endpoint that accepts exactly one input: a validated/sanitized phone number (E.164) or a validated email (case-insensitive).
  - Returns masked contact details plus the recipient’s primary wallet currency, or `null` when no wallet exists.

- **Bug Fixes**
  - Strengthened request validation and auth error handling.
  - Prevents exposure of raw email/phone (and password-related fields) and improves masking for short valid E.164 numbers.

- **Tests**
  - Expanded coverage for all success and failure paths, including wallet presence/absence.

- **Chores**
  - Added a post-install script to patch Jest mocking behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->