### PR TITLE
feat: add profile management endpoint

### DIFF
--- a/backend/src/api/users/profile/route.ts
+++ b/backend/src/api/users/profile/route.ts
@@ -1,0 +1,70 @@
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { getAuthPayload } from "@/lib/auth-session";
+import { createProblemDetails } from "@/lib/api-utils";
+import { userProfileUpdateSchema } from "@/lib/validations/auth";
+
+export async function PUT(request: NextRequest) {
+  try {
+    const payload = await getAuthPayload(request);
+    if (!payload) {
+      return createProblemDetails("about:blank", "Unauthorized", 401, "Unauthorized");
+    }
+
+    if (!request.headers.get("content-type")?.includes("application/json")) {
+      return createProblemDetails("about:blank", "Bad Request", 400, "Invalid Content-Type. Expected application/json");
+    }
+
+    let body: unknown;
+    try {
+      body = await request.json();
+    } catch {
+      return createProblemDetails("about:blank", "Bad Request", 400, "Request body must be valid JSON");
+    }
+
+    const validation = userProfileUpdateSchema.safeParse(body);
+    if (!validation.success) {
+      return createProblemDetails("about:blank", "Bad Request", 400, "Invalid profile details", undefined, {
+        errors: validation.error.flatten().fieldErrors,
+      });
+    }
+
+    const [updatedUser] = await db
+      .update(users)
+      .set({ ...validation.data, updatedAt: new Date() })
+      .where(eq(users.id, payload.userId))
+      .returning({
+        id: users.id,
+        name: users.name,
+        phoneNumber: users.phoneNumber,
+        email: users.email,
+        avatarUrl: users.avatarUrl,
+        username: users.username,
+        role: users.role,
+        status: users.status,
+        createdAt: users.createdAt,
+        updatedAt: users.updatedAt,
+      });
+
+    if (!updatedUser) {
+      return createProblemDetails("about:blank", "Not Found", 404, "User not found");
+    }
+
+    return NextResponse.json({ success: true, user: updatedUser }, { status: 200 });
+  } catch (error: unknown) {
+    const databaseError = error as { code?: string; constraint?: string };
+    if (databaseError.code === "23505") {
+      const field = databaseError.constraint?.includes("phone")
+        ? "Phone number"
+        : databaseError.constraint?.includes("email")
+          ? "Email address"
+          : "Profile value";
+      return createProblemDetails("about:blank", "Conflict", 409, `${field} is already in use`);
+    }
+
+    console.error("[PROFILE_UPDATE_ERROR]", error);
+    return createProblemDetails("about:blank", "Internal Server Error", 500, "Internal server error");
+  }
+}

--- a/backend/src/lib/validations/auth.ts
+++ b/backend/src/lib/validations/auth.ts
@@ -35,5 +35,43 @@ export const profileUpdateSchema = z.object({
 });
 export type ProfileUpdateSchema = z.infer<typeof profileUpdateSchema>;
 
+const avatarUrlField = z
+  .string()
+  .trim()
+  .max(2048, "Avatar URL is too long")
+  .url("Invalid avatar URL")
+  .refine((value) => {
+    try {
+      const protocol = new URL(value).protocol;
+      return protocol === "http:" || protocol === "https:";
+    } catch {
+      return false;
+    }
+  }, "Avatar URL must use HTTP or HTTPS");
+
+export const userProfileUpdateSchema = z
+  .object({
+    name: z
+      .string()
+      .trim()
+      .min(2, "Name must be at least 2 characters")
+      .max(100, "Name must be at most 100 characters")
+      .optional(),
+    phoneNumber: phoneField.optional(),
+    email: z
+      .string()
+      .trim()
+      .toLowerCase()
+      .email("Invalid email address")
+      .max(254, "Email address is too long")
+      .optional(),
+    avatarUrl: avatarUrlField.nullable().optional(),
+  })
+  .strict()
+  .refine((value) => Object.keys(value).length > 0, {
+    message: "At least one profile field must be provided",
+  });
+
+export type UserProfileUpdate = z.infer<typeof userProfileUpdateSchema>;
 export const isValidE164 = (value: unknown): value is PhoneNumber =>
   phoneField.safeParse(value).success;

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -50,6 +50,7 @@ import { POST as giftAppreciatePost } from "./api/gifts/appreciate/route";
 // Users
 import { GET as resolveRecipientGet } from "./api/users/resolve/route";
 import { DELETE as deleteAccountDelete } from "./api/users/account/route";
+import { PUT as updateProfilePut } from "./api/users/profile/route";
 import { POST as forgotPasswordPost } from "./api/auth/forgot-password/route";
 import { POST as loginPost } from "./api/auth/login/route";
 import { POST as logoutPost } from "./api/auth/logout/route";
@@ -105,3 +106,4 @@ apiRouter.post("/api/upload/image", limitUploadSize, makeExpressHandler(uploadIm
 // 5. Users routes
 apiRouter.get("/api/users/resolve", makeExpressHandler(resolveRecipientGet));
 apiRouter.delete("/api/users/account", makeExpressHandler(deleteAccountDelete));
+apiRouter.put("/api/users/profile", makeExpressHandler(updateProfilePut));


### PR DESCRIPTION
## Summary

- add an authenticated `PUT /api/users/profile` endpoint
- validate and normalize name, E.164 phone number, email address, and HTTP(S) avatar URL updates
- update only the authenticated user's record with Drizzle ORM and return the refreshed profile
- handle malformed requests, missing users, and duplicate email or phone conflicts with problem-detail responses

## Validation

- `git diff --check`
- TypeScript and Jest checks could not be run locally because dependencies are not installed and the configured package registry was unavailable

Closes #342

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the ability to update user profiles through the profile API.
  * Profile updates support names, phone numbers, email addresses, and avatar URLs.
  * Added validation for supported URL formats, valid profile data, and non-empty updates.
  * Clear responses are provided for invalid data, missing profiles, and duplicate contact details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->