### PR TITLE
fix: implement action OTP send endpoint with action-specific email dispatching

### DIFF
--- a/backend/__tests__/api/auth/action-otp.test.ts
+++ b/backend/__tests__/api/auth/action-otp.test.ts
@@ -31,7 +31,7 @@ jest.mock("@/server/services/otpService", () => ({
 }));
 
 jest.mock("@/server/services/emailService", () => ({
-  sendVerificationEmail: jest.fn().mockResolvedValue({ success: true }),
+  sendActionOtpEmail: jest.fn().mockResolvedValue({ success: true }),
 }));
 
 describe("POST /api/auth/action-otp/send Endpoint", () => {
@@ -77,10 +77,15 @@ describe("POST /api/auth/action-otp/send Endpoint", () => {
     expect(response.status).toBe(200);
     expect(data.success).toBe(true);
     expect(data.action).toBe("transfer_confirm");
-    expect(otpService.storeOTP).toHaveBeenCalledWith(mockUser.id, "654321");
-    expect(emailService.sendVerificationEmail).toHaveBeenCalledWith(
+    expect(otpService.storeOTP).toHaveBeenCalledWith(
+      mockUser.id,
+      "654321",
+      "transfer_confirm",
+    );
+    expect(emailService.sendActionOtpEmail).toHaveBeenCalledWith(
       mockUser.email,
       "654321",
+      "transfer_confirm",
       mockUser.name,
     );
   });
@@ -136,7 +141,7 @@ describe("POST /api/auth/action-otp/send Endpoint", () => {
       email: mockUser.email,
     });
     (db.query.users.findFirst as jest.Mock).mockResolvedValue(mockUser);
-    (emailService.sendVerificationEmail as jest.Mock).mockResolvedValueOnce({
+    (emailService.sendActionOtpEmail as jest.Mock).mockResolvedValueOnce({
       success: false,
       error: "SMTP Error",
     });

--- a/backend/src/api/auth/action-otp/route.ts
+++ b/backend/src/api/auth/action-otp/route.ts
@@ -8,7 +8,7 @@ import {
   storeOTP,
   checkOTPRequestRateLimitByUserId,
 } from "@/server/services/otpService";
-import { sendVerificationEmail } from "@/server/services/emailService";
+import { sendActionOtpEmail } from "@/server/services/emailService";
 import { createProblemDetails } from "@/lib/api-utils";
 import {
   checkActionOtpCooldown,
@@ -25,6 +25,11 @@ const ALLOWED_ACTIONS = new Set([
   "email_verification",
   "profile_update",
   "login_2fa",
+  "delete_account",
+  "disable_2fa",
+  "change_email",
+  "change_password",
+  "withdraw_funds",
 ]);
 
 export async function POST(request: NextRequest) {
@@ -118,11 +123,12 @@ export async function POST(request: NextRequest) {
     }
 
     const otp = generateOTP();
-    await storeOTP(user.id, otp);
+    await storeOTP(user.id, otp, action);
 
-    const emailResult = await sendVerificationEmail(
+    const emailResult = await sendActionOtpEmail(
       user.email,
       otp,
+      action,
       user.name || undefined,
     );
 

--- a/backend/src/server/services/emailService.ts
+++ b/backend/src/server/services/emailService.ts
@@ -465,6 +465,96 @@ function generateBaseTemplate({
   `.trim();
 }
 
+export async function sendActionOtpEmail(
+  email: string,
+  otp: string,
+  action: string,
+  userName?: string,
+) {
+  const actionLabels: Record<string, string> = {
+    delete_account: "Account Deletion",
+    disable_2fa: "Disable Two-Factor Authentication",
+    change_email: "Change Email Address",
+    change_password: "Change Password",
+    withdraw_funds: "Withdraw Funds",
+    default: "Sensitive Action",
+  };
+
+  const actionLabel = actionLabels[action] || "Sensitive Action";
+
+  const mailOptions = {
+    from: `"Zendvo" <${EMAIL_CONFIG.auth.user}>`,
+    to: email,
+    subject: `${actionLabel} Verification Code - Zendvo`,
+    html: generateActionOtpTemplate(otp, actionLabel, userName),
+    text: `Your Zendvo ${actionLabel} verification code is: ${otp}\n\nThis code will expire in 10 minutes.\n\nIf you didn't request this code, please ignore this email.`,
+  };
+
+  try {
+    if (process.env.NODE_ENV === "development") {
+      console.log("=".repeat(50));
+      console.log(`ACTION OTP EMAIL (Development Mode)`);
+      console.log("=".repeat(50));
+      console.log(`Action: ${actionLabel}`);
+      console.log(`To: ${email}`);
+      console.log(`OTP Code: ${otp}`);
+      console.log(`Expires: 10 minutes`);
+      console.log("=".repeat(50));
+      return {
+        success: true,
+        messageId: "dev-mode",
+        message: "Action OTP logged to console (development mode)",
+      };
+    }
+
+    const info = await transporter.sendMail(mailOptions);
+    return {
+      success: true,
+      messageId: info.messageId,
+      message: "Action OTP email sent successfully",
+    };
+  } catch (error) {
+    console.error("Error sending action OTP email:", error);
+    return {
+      success: false,
+      error: error instanceof Error ? error.message : "Unknown error",
+      message: "Failed to send action OTP email",
+      detail: error instanceof Error ? error.message : "Unknown error",
+    };
+  }
+}
+
+function generateActionOtpTemplate(
+  otp: string,
+  actionLabel: string,
+  userName?: string,
+): string {
+  return generateBaseTemplate({
+    title: `${actionLabel} Verification`,
+    userName,
+    content: `
+      <p style="margin: 0 0 20px; color: #4a5568; font-size: 16px; line-height: 1.6;">
+        You are attempting to <strong>${actionLabel}</strong> on your Zendvo account. 
+        To proceed, please use the verification code below:
+      </p>
+      
+      <table width="100%" cellpadding="0" cellspacing="0" style="margin: 30px 0;">
+        <tr>
+          <td align="center" style="background-color: #f7fafc; border: 2px dashed #667eea; border-radius: 8px; padding: 30px;">
+            <div style="font-size: 36px; font-weight: 700; color: #667eea; letter-spacing: 8px; font-family: 'Courier New', monospace;">
+              ${otp}
+            </div>
+          </td>
+        </tr>
+      </table>
+      
+      <p style="margin: 20px 0; color: #4a5568; font-size: 14px; line-height: 1.6;">
+        <strong>⏰ This code will expire in 10 minutes.</strong>
+      </p>
+    `,
+  });
+}
+
 export async function sendGiftConfirmationOTP(
   email: string,
   otp: string,


### PR DESCRIPTION
Closes #346

---

## Overview

Implements the OTP generation and dispatch endpoint \POST /api/auth/action-otp/send\ as described in issue #346.

## Changes

- \ackend/src/api/auth/action-otp/route.ts\ — Pass the \ction\ parameter to \storeOTP()\ so OTPs are scoped to user_id + action_type; expand ALLOWED_ACTIONS to include all ActionType values; switch from generic sendVerificationEmail to action-specific sendActionOtpEmail
- \ackend/src/server/services/emailService.ts\ — Add \sendActionOtpEmail()\ and \generateActionOtpTemplate()\ for action-specific OTP email dispatching via nodemailer
- \ackend/__tests__/api/auth/action-otp.test.ts\ — Update mocks and assertions to match the new sendActionOtpEmail and scoped storeOTP calls

## Verification
- All 8 action-otp tests pass
- No new TypeScript errors