### PR TITLE
feat(mobile): local XDR parsing and cryptographic signing service

### DIFF
--- a/mobile/android/gradle/wrapper/gradle-wrapper.properties
+++ b/mobile/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip

--- a/mobile/lib/core/services/transaction_signing_service.dart
+++ b/mobile/lib/core/services/transaction_signing_service.dart
@@ -6,11 +6,13 @@ import 'secure_storage_service.dart';
 /// secret seed from secure storage. Keeps the architecture non-custodial:
 /// the private key never leaves the device.
 class TransactionSigningService {
+  /// Both [secureStorage] and [network] are required so callers cannot
+  /// accidentally sign with a stub storage or the wrong network passphrase.
   TransactionSigningService({
-    SecureStorageService? secureStorage,
-    Network? network,
-  })  : _secureStorage = secureStorage ?? SecureStorageService(),
-        _network = network ?? Network.TESTNET;
+    required SecureStorageService secureStorage,
+    required Network network,
+  })  : _secureStorage = secureStorage,
+        _network = network;
 
   final SecureStorageService _secureStorage;
   final Network _network;

--- a/mobile/lib/core/services/transaction_signing_service.dart
+++ b/mobile/lib/core/services/transaction_signing_service.dart
@@ -1,8 +1,54 @@
-// Placeholder: Transaction Signing Service
-// Decodes XDR, signs it with the local secret seed, and re-encodes.
+import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
+
+import 'secure_storage_service.dart';
+
+/// Locally signs an unsigned Stellar transaction XDR using the user's
+/// secret seed from secure storage. Keeps the architecture non-custodial:
+/// the private key never leaves the device.
 class TransactionSigningService {
-  Future<String> signXdrLocally(String unsignedXdr, String secretSeed) async {
-    // TODO: Implement stellar_flutter_sdk envelope signing
-    return 'signed_xdr_placeholder';
+  TransactionSigningService({
+    SecureStorageService? secureStorage,
+    Network? network,
+  })  : _secureStorage = secureStorage ?? SecureStorageService(),
+        _network = network ?? Network.TESTNET;
+
+  final SecureStorageService _secureStorage;
+  final Network _network;
+
+  /// Decodes [unsignedXdr], signs with the stored secret seed, and returns
+  /// a signed Base64 XDR envelope ready for network submission.
+  Future<String> signXdrLocally(String unsignedXdr) async {
+    if (unsignedXdr.trim().isEmpty) {
+      throw ArgumentError('unsignedXdr must not be empty');
+    }
+
+    String? secretSeed;
+    try {
+      secretSeed = await _secureStorage.getSecretSeed();
+      if (secretSeed == null || secretSeed.isEmpty) {
+        throw StateError(
+          'No secret seed found in secure storage. '
+          'Generate or restore a wallet before signing.',
+        );
+      }
+
+      final AbstractTransaction transaction;
+      try {
+        transaction =
+            AbstractTransaction.fromEnvelopeXdrString(unsignedXdr);
+      } catch (e) {
+        throw FormatException(
+          'Malformed or invalid Base64 XDR transaction envelope: $e',
+        );
+      }
+
+      final keyPair = KeyPair.fromSecretSeed(secretSeed);
+      transaction.sign(keyPair, _network);
+
+      return transaction.toEnvelopeXdrBase64();
+    } finally {
+      // Drop local reference ASAP; do not log or return the seed.
+      secretSeed = null;
+    }
   }
 }

--- a/mobile/lib/core/services/transaction_signing_service.dart
+++ b/mobile/lib/core/services/transaction_signing_service.dart
@@ -24,6 +24,17 @@ class TransactionSigningService {
       throw ArgumentError('unsignedXdr must not be empty');
     }
 
+    // Validate XDR before touching the secret seed so malformed input
+    // never pulls the private key into memory.
+    final AbstractTransaction transaction;
+    try {
+      transaction = AbstractTransaction.fromEnvelopeXdrString(unsignedXdr);
+    } catch (e) {
+      throw FormatException(
+        'Malformed or invalid Base64 XDR transaction envelope: $e',
+      );
+    }
+
     String? secretSeed;
     try {
       secretSeed = await _secureStorage.getSecretSeed();
@@ -31,16 +42,6 @@ class TransactionSigningService {
         throw StateError(
           'No secret seed found in secure storage. '
           'Generate or restore a wallet before signing.',
-        );
-      }
-
-      final AbstractTransaction transaction;
-      try {
-        transaction =
-            AbstractTransaction.fromEnvelopeXdrString(unsignedXdr);
-      } catch (e) {
-        throw FormatException(
-          'Malformed or invalid Base64 XDR transaction envelope: $e',
         );
       }
 

--- a/mobile/pubspec.lock
+++ b/mobile/pubspec.lock
@@ -41,6 +41,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
+  convert:
+    dependency: transitive
+    description:
+      name: convert
+      sha256: b30acd5944035672bc15c6b7a8b47d773e41e2f17de064350988c5d02adb1c68
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
+  crypto:
+    dependency: transitive
+    description:
+      name: crypto
+      sha256: c8ea0233063ba03258fbcf2ca4d6dadfefe14f02fab57702265467a19f27fadf
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.0.7"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -49,6 +65,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.9"
+  decimal:
+    dependency: transitive
+    description:
+      name: decimal
+      sha256: "2c3c8b74f2948066d3f42585477aec9cfc48fefd7a723a4d4274a6c71a5c0df7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.6"
+  dio:
+    dependency: transitive
+    description:
+      name: dio
+      sha256: "0df44ebba85e503958eb75d07eedd3c86275a58c1d3eda2f2ce8f0a2c3abbb3c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.11.0"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "0786d0b7295a373de356fc0af4f6f1d0ab2844ed31b19dfc5e7556b70e24212c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.1"
   fake_async:
     dependency: transitive
     description:
@@ -75,6 +115,35 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  flutter_web_plugins:
+    dependency: transitive
+    description: flutter
+    source: sdk
+    version: "0.0.0"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
+  http_parser:
+    dependency: transitive
+    description:
+      name: http_parser
+      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.2"
+  intl:
+    dependency: transitive
+    description:
+      name: intl
+      sha256: "1ca20c894b1717686a2319b8548763d812bc0aabdac580420a44c5178c57a867"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.20.3"
   leak_tracker:
     dependency: transitive
     description:
@@ -131,6 +200,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.16.0"
+  mime:
+    dependency: transitive
+    description:
+      name: mime
+      sha256: "41a20518f0cb1256669420fdba0cd90d21561e560ac240f26ef8322e45bb7ed6"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.0"
   path:
     dependency: transitive
     description:
@@ -139,6 +216,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: "91bd59303e9f769f108f8df05e371341b15d59e995e6806aefab827b58336675"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.2"
+  pinenacl:
+    dependency: transitive
+    description:
+      name: pinenacl
+      sha256: "57e907beaacbc3c024a098910b6240758e899674de07d6949a67b52fd984cbdf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.0"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
+  rational:
+    dependency: transitive
+    description:
+      name: rational
+      sha256: cb808fb6f1a839e6fc5f7d8cb3b0a10e1db48b3be102de73938c627f0b636336
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.3"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -160,6 +269,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.12.1"
+  stellar_flutter_sdk:
+    dependency: "direct main"
+    description:
+      name: stellar_flutter_sdk
+      sha256: "2df676324e09e81032da75665b46dadac91178a8b8c0e5d4e1c09568305c873d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.5.0"
   stream_channel:
     dependency: transitive
     description:
@@ -192,6 +309,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.6"
+  toml:
+    dependency: transitive
+    description:
+      name: toml
+      sha256: "35cd2a1351c14bd213f130f8efcbd3e0c18181bff0c8ca7a08f6822a2bede786"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.17.0"
+  typed_data:
+    dependency: transitive
+    description:
+      name: typed_data
+      sha256: f9049c039ebfeb4cf7a7104a675823cd72dba8297f264b6637062516699fa006
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.4.0"
+  unorm_dart:
+    dependency: transitive
+    description:
+      name: unorm_dart
+      sha256: "0c69186b03ca6addab0774bcc0f4f17b88d4ce78d9d4d8f0619e30a99ead58e7"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.2"
   vector_math:
     dependency: transitive
     description:
@@ -208,6 +349,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "15.2.0"
+  web:
+    dependency: transitive
+    description:
+      name: web
+      sha256: "868d88a33d8a87b18ffc05f9f030ba328ffefba92d6c127917a2ba740f9cfe4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
 sdks:
   dart: ">=3.9.2 <4.0.0"
-  flutter: ">=3.18.0-18.0.pre.54"
+  flutter: ">=3.32.0"

--- a/mobile/pubspec.yaml
+++ b/mobile/pubspec.yaml
@@ -34,6 +34,7 @@ dependencies:
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
   cupertino_icons: ^1.0.8
+  stellar_flutter_sdk: ^3.5.0
 
 dev_dependencies:
   flutter_test:

--- a/mobile/test/services/transaction_signing_service_test.dart
+++ b/mobile/test/services/transaction_signing_service_test.dart
@@ -12,22 +12,25 @@ class _FakeSecureStorage extends SecureStorageService {
   Future<String?> getSecretSeed() async => _seed;
 }
 
+String _buildUnsignedPaymentXdr(KeyPair keyPair) {
+  final account = Account(keyPair.accountId, BigInt.one);
+  final unsigned = TransactionBuilder(account)
+      .addOperation(
+        PaymentOperationBuilder(
+          keyPair.accountId,
+          Asset.NATIVE,
+          '1',
+        ).build(),
+      )
+      .build();
+  return unsigned.toEnvelopeXdrBase64();
+}
+
 void main() {
-  test('signs unsigned XDR with seed from secure storage', () async {
+  test('signs unsigned XDR for TESTNET with seed from secure storage',
+      () async {
     final keyPair = KeyPair.random();
-    final account = Account(keyPair.accountId, BigInt.one);
-
-    final unsigned = TransactionBuilder(account)
-        .addOperation(
-          PaymentOperationBuilder(
-            keyPair.accountId,
-            Asset.NATIVE,
-            '1',
-          ).build(),
-        )
-        .build();
-
-    final unsignedXdr = unsigned.toEnvelopeXdrBase64();
+    final unsignedXdr = _buildUnsignedPaymentXdr(keyPair);
 
     final service = TransactionSigningService(
       secureStorage: _FakeSecureStorage(keyPair.secretSeed),
@@ -43,9 +46,42 @@ void main() {
     expect(parsed.signatures, isNotEmpty);
   });
 
+  test('signs unsigned XDR for PUBLIC network', () async {
+    final keyPair = KeyPair.random();
+    final unsignedXdr = _buildUnsignedPaymentXdr(keyPair);
+
+    final service = TransactionSigningService(
+      secureStorage: _FakeSecureStorage(keyPair.secretSeed),
+      network: Network.PUBLIC,
+    );
+
+    final signedXdr = await service.signXdrLocally(unsignedXdr);
+    final parsed = AbstractTransaction.fromEnvelopeXdrString(signedXdr);
+    expect(parsed.signatures, isNotEmpty);
+  });
+
+  test('TESTNET and PUBLIC signatures differ for the same XDR', () async {
+    final keyPair = KeyPair.random();
+    final unsignedXdr = _buildUnsignedPaymentXdr(keyPair);
+    final storage = _FakeSecureStorage(keyPair.secretSeed);
+
+    final testnetSigned = await TransactionSigningService(
+      secureStorage: storage,
+      network: Network.TESTNET,
+    ).signXdrLocally(unsignedXdr);
+
+    final publicSigned = await TransactionSigningService(
+      secureStorage: storage,
+      network: Network.PUBLIC,
+    ).signXdrLocally(unsignedXdr);
+
+    expect(testnetSigned, isNot(equals(publicSigned)));
+  });
+
   test('throws when secret seed is missing', () async {
     final service = TransactionSigningService(
       secureStorage: _FakeSecureStorage(null),
+      network: Network.TESTNET,
     );
 
     expect(
@@ -58,6 +94,7 @@ void main() {
     final keyPair = KeyPair.random();
     final service = TransactionSigningService(
       secureStorage: _FakeSecureStorage(keyPair.secretSeed),
+      network: Network.TESTNET,
     );
 
     expect(

--- a/mobile/test/services/transaction_signing_service_test.dart
+++ b/mobile/test/services/transaction_signing_service_test.dart
@@ -12,6 +12,18 @@ class _FakeSecureStorage extends SecureStorageService {
   Future<String?> getSecretSeed() async => _seed;
 }
 
+class _CountingSecureStorage extends SecureStorageService {
+  _CountingSecureStorage({required this.onRead});
+
+  final void Function() onRead;
+
+  @override
+  Future<String?> getSecretSeed() async {
+    onRead();
+    return 'should-not-be-read';
+  }
+}
+
 String _buildUnsignedPaymentXdr(KeyPair keyPair) {
   final account = Account(keyPair.accountId, BigInt.one);
   final unsigned = TransactionBuilder(account)
@@ -79,15 +91,34 @@ void main() {
   });
 
   test('throws when secret seed is missing', () async {
+    final keyPair = KeyPair.random();
+    final unsignedXdr = _buildUnsignedPaymentXdr(keyPair);
     final service = TransactionSigningService(
       secureStorage: _FakeSecureStorage(null),
       network: Network.TESTNET,
     );
 
     expect(
-      () => service.signXdrLocally('AAAA...'),
+      () => service.signXdrLocally(unsignedXdr),
       throwsA(isA<StateError>()),
     );
+  });
+
+  test('does not read secret seed when XDR is malformed', () async {
+    var seedReads = 0;
+    final storage = _CountingSecureStorage(
+      onRead: () => seedReads++,
+    );
+    final service = TransactionSigningService(
+      secureStorage: storage,
+      network: Network.TESTNET,
+    );
+
+    await expectLater(
+      () => service.signXdrLocally('not-valid-xdr'),
+      throwsA(isA<FormatException>()),
+    );
+    expect(seedReads, 0);
   });
 
   test('throws on malformed XDR', () async {

--- a/mobile/test/services/transaction_signing_service_test.dart
+++ b/mobile/test/services/transaction_signing_service_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mobile/core/services/secure_storage_service.dart';
+import 'package:mobile/core/services/transaction_signing_service.dart';
+import 'package:stellar_flutter_sdk/stellar_flutter_sdk.dart';
+
+class _FakeSecureStorage extends SecureStorageService {
+  _FakeSecureStorage(this._seed);
+
+  final String? _seed;
+
+  @override
+  Future<String?> getSecretSeed() async => _seed;
+}
+
+void main() {
+  test('signs unsigned XDR with seed from secure storage', () async {
+    final keyPair = KeyPair.random();
+    final account = Account(keyPair.accountId, BigInt.one);
+
+    final unsigned = TransactionBuilder(account)
+        .addOperation(
+          PaymentOperationBuilder(
+            keyPair.accountId,
+            Asset.NATIVE,
+            '1',
+          ).build(),
+        )
+        .build();
+
+    final unsignedXdr = unsigned.toEnvelopeXdrBase64();
+
+    final service = TransactionSigningService(
+      secureStorage: _FakeSecureStorage(keyPair.secretSeed),
+      network: Network.TESTNET,
+    );
+
+    final signedXdr = await service.signXdrLocally(unsignedXdr);
+
+    expect(signedXdr, isNotEmpty);
+    expect(signedXdr, isNot(equals(unsignedXdr)));
+
+    final parsed = AbstractTransaction.fromEnvelopeXdrString(signedXdr);
+    expect(parsed.signatures, isNotEmpty);
+  });
+
+  test('throws when secret seed is missing', () async {
+    final service = TransactionSigningService(
+      secureStorage: _FakeSecureStorage(null),
+    );
+
+    expect(
+      () => service.signXdrLocally('AAAA...'),
+      throwsA(isA<StateError>()),
+    );
+  });
+
+  test('throws on malformed XDR', () async {
+    final keyPair = KeyPair.random();
+    final service = TransactionSigningService(
+      secureStorage: _FakeSecureStorage(keyPair.secretSeed),
+    );
+
+    expect(
+      () => service.signXdrLocally('not-valid-xdr'),
+      throwsA(isA<FormatException>()),
+    );
+  });
+}


### PR DESCRIPTION
## Summary
Adds a non-custodial local signing path for the Flutter app: unsigned Base64 XDR from the backend is decoded, signed with the user's secret seed from `SecureStorageService`, and returned as signed Base64 XDR ready for network submission. The private key never leaves the device.

Closes #374

## Changes
- Implement `TransactionSigningService.signXdrLocally` with `stellar_flutter_sdk` (`fromEnvelopeXdrString` → `sign` → `toEnvelopeXdrBase64`)
- Load the secret seed from `SecureStorageService` and clear the local reference after signing
- Support network selection via `Network.TESTNET` / `Network.PUBLIC` (defaults to testnet)
- Handle empty XDR, missing seed, and malformed envelopes with clear errors
- Add `stellar_flutter_sdk: ^3.5.0`
- Add unit tests for successful signing, missing seed, and malformed XDR

## Test plan
- [x] `flutter analyze` on the service and test files
- [x] `flutter test test/services/transaction_signing_service_test.dart`
- [x] `flutter test` (full mobile suite)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added local transaction signing using securely stored account credentials.
  * Transactions are signed for the selected network and returned in Base64 format.
* **Bug Fixes**
  * Improved handling of missing credentials and malformed transaction data with clear validation errors.
  * Prevented access to sensitive signing information when transaction data is invalid.
  * Cleared sensitive local signing information after signing attempts.
* **Quality Improvements**
  * Added coverage for signing across supported networks and invalid-input scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->