### PR TITLE
feat: implement DeFindex vault deposit XDR builder

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",
+    "@defindex/sdk": "^1.0.0",
     "@libsql/client": "^0.17.0",
     "@prisma/client": "^7.5.0",
     "@stellar/stellar-sdk": "^14.4.3",

--- a/backend/src/api/wallet/deposit.ts
+++ b/backend/src/api/wallet/deposit.ts
@@ -1,5 +1,99 @@
-// Placeholder: API Endpoint to Serve Deposit Payload
-// Will interface with defindex_service to calculate DeFindex Deposit XDR Parameters.
-export const depositEndpoint = async (req: any, res: any) => {
-  res.status(501).json({ message: "Not implemented yet" });
-};
+import { NextRequest, NextResponse } from "next/server";
+import { getAuthPayload } from "@/lib/auth-session";
+import { createProblemDetails } from "@/lib/api-utils";
+import {
+  buildDeFindexDepositXdr,
+  DeFindexServiceError,
+} from "@/lib/services/defindex_service";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function POST(request: NextRequest) {
+  // 1. Authenticate
+  const payload = await getAuthPayload(request);
+  if (!payload) {
+    return createProblemDetails(
+      "about:blank",
+      "Unauthorized",
+      401,
+      "Authentication required",
+    );
+  }
+
+  // 2. Parse body
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    body = {};
+  }
+
+  const { amount } =
+    body !== null && typeof body === "object" && !Array.isArray(body)
+      ? (body as { amount?: unknown })
+      : { amount: undefined };
+
+  if (typeof amount !== "string" || !amount.trim()) {
+    return createProblemDetails(
+      "about:blank",
+      "Bad Request",
+      400,
+      'amount is required and must be a non-empty string (e.g. "50.00")',
+    );
+  }
+
+  // 3. Resolve the user's registered Stellar address
+  const [user] = await db
+    .select({ stellarAddress: users.stellarAddress })
+    .from(users)
+    .where(eq(users.id, payload.userId));
+
+  if (!user) {
+    return createProblemDetails(
+      "about:blank",
+      "Not Found",
+      404,
+      "User not found",
+    );
+  }
+
+  if (!user.stellarAddress) {
+    return createProblemDetails(
+      "about:blank",
+      "Unprocessable Entity",
+      422,
+      "No Stellar address registered for this account. Register one via /api/wallet/register first.",
+    );
+  }
+
+  // 4. Build the unsigned deposit XDR via DeFindex service
+  try {
+    const unsignedXdr = await buildDeFindexDepositXdr(
+      user.stellarAddress,
+      amount.trim(),
+    );
+
+    return NextResponse.json({ unsignedXdr });
+  } catch (err) {
+    if (err instanceof DeFindexServiceError) {
+      // Surface validation / config problems as 422
+      const isConfig = err.message.includes("DEFINDEX_VAULT_CONTRACT_ID");
+      const status = isConfig ? 503 : 422;
+      return createProblemDetails(
+        "about:blank",
+        isConfig ? "Service Unavailable" : "Unprocessable Entity",
+        status,
+        err.message,
+      );
+    }
+
+    console.error("[deposit] Unexpected error:", err);
+    return createProblemDetails(
+      "about:blank",
+      "Internal Server Error",
+      500,
+      "An unexpected error occurred while building the deposit transaction.",
+    );
+  }
+}

--- a/backend/src/lib/services/defindex_service.ts
+++ b/backend/src/lib/services/defindex_service.ts
@@ -1,8 +1,123 @@
-// Placeholder: DeFindex SDK Service
-// Interfaces with the DeFindex SDK to calculate parameters for deposits and withdrawals.
-export class DefindexService {
-  static async calculateDepositXdr(userAddress: string, amount: string): Promise<string> {
-    // TODO: Connect to Soroban RPC / DeFindex SDK to build payload
-    return "base64_unsigned_xdr_placeholder";
+/**
+ * DeFindex Service
+ *
+ * Interfaces with the DeFindex API (via @defindex/sdk) to construct unsigned
+ * Soroban XDR payloads for USDC vault deposits. The returned XDR must be
+ * signed by the user's wallet before submission to the network.
+ */
+import { StrKey } from "@stellar/stellar-sdk";
+
+/** Number of decimal places used by the Stellar/Soroban convention (1e7 stroops = 1 unit). */
+const STROOPS_PER_UNIT = 10_000_000n;
+
+export class DeFindexServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly cause?: Error,
+  ) {
+    super(message);
+    this.name = "DeFindexServiceError";
   }
+}
+
+/**
+ * Converts a human-readable decimal amount string (e.g. "50.00") to the
+ * integer stroop value required by the DeFindex vault contract (7 decimals).
+ *
+ * Throws if the input is not a valid positive decimal number.
+ */
+export function toStroops(amount: string): bigint {
+  const trimmed = amount.trim();
+  if (!/^\d+(\.\d+)?$/.test(trimmed) || Number(trimmed) <= 0) {
+    throw new DeFindexServiceError(
+      `Invalid deposit amount: "${amount}". Must be a positive number such as "50.00".`,
+    );
+  }
+
+  const [whole, fraction = ""] = trimmed.split(".");
+  // Pad or truncate fraction to exactly 7 decimal places
+  const decimals = fraction.padEnd(7, "0").slice(0, 7);
+  return BigInt(whole) * STROOPS_PER_UNIT + BigInt(decimals);
+}
+
+/**
+ * Builds a fee-estimated, unsigned XDR for a DeFindex vault deposit.
+ *
+ * The DeFindex SDK handles:
+ *  - Constructing the Soroban contract invocation with correct ScVal types
+ *  - Simulating the transaction against the Soroban RPC
+ *  - Applying resource fees from the simulation result
+ *
+ * The caller must sign the returned XDR before submitting it to the network.
+ *
+ * @param userAddress - Valid Stellar Ed25519 public key (G…) of the depositor.
+ * @param amount      - Human-readable deposit amount, e.g. "50.00".
+ * @returns           - Base64-encoded unsigned transaction XDR string.
+ */
+export async function buildDeFindexDepositXdr(
+  userAddress: string,
+  amount: string,
+): Promise<string> {
+  // --- Validate inputs ---
+  if (!StrKey.isValidEd25519PublicKey(userAddress)) {
+    throw new DeFindexServiceError(`Invalid Stellar address: "${userAddress}"`);
+  }
+
+  const stroops = toStroops(amount);
+
+  // --- Read environment config ---
+  const vaultAddress = process.env.DEFINDEX_VAULT_CONTRACT_ID;
+  if (!vaultAddress || !StrKey.isValidContract(vaultAddress)) {
+    throw new DeFindexServiceError(
+      "DEFINDEX_VAULT_CONTRACT_ID is not configured or is not a valid contract address.",
+    );
+  }
+
+  const apiKey = process.env.DEFINDEX_API_KEY;
+  if (!apiKey) {
+    throw new DeFindexServiceError("DEFINDEX_API_KEY is not configured.");
+  }
+
+  const baseUrl = process.env.DEFINDEX_API_URL || "https://api.defindex.io";
+  const networkEnv = process.env.STELLAR_NETWORK || "TESTNET";
+
+  // --- Dynamically import SDK to keep it server-side only ---
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const { DefindexSDK, SupportedNetworks } = await import("@defindex/sdk");
+
+  const network =
+    networkEnv === "MAINNET"
+      ? SupportedNetworks.MAINNET
+      : SupportedNetworks.TESTNET;
+
+  const sdk = new DefindexSDK({ apiKey, baseUrl });
+
+  // --- Call the DeFindex API to build the deposit XDR ---
+  let response: { xdr: string };
+  try {
+    response = await sdk.depositToVault(
+      vaultAddress,
+      {
+        // amounts: integer stroop values per vault asset (single USDC asset vault)
+        amounts: [Number(stroops)],
+        caller: userAddress,
+        invest: true,
+        slippageBps: 100, // 1% slippage tolerance
+      },
+      network,
+    );
+  } catch (err) {
+    throw new DeFindexServiceError(
+      `DeFindex API request failed: ${err instanceof Error ? err.message : String(err)}`,
+      err instanceof Error ? err : new Error(String(err)),
+    );
+  }
+
+  if (!response?.xdr) {
+    throw new DeFindexServiceError(
+      "DeFindex API returned an empty XDR payload.",
+    );
+  }
+
+  return response.xdr;
 }


### PR DESCRIPTION
- Add buildDeFindexDepositXdr(userAddress, amount) in defindex_service.ts
- Add toStroops() to convert decimal amounts to 7-decimal integer stroops
- Add DeFindexServiceError typed error class
- Implement POST /api/wallet/deposit endpoint with auth, input validation,
  Stellar address resolution, and unsigned XDR response
- Add @defindex/sdk dependency to package.json

fixes #381


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an authenticated wallet deposit endpoint.
  - Validates deposit amounts and registered wallet addresses.
  - Generates unsigned DeFindex deposit transactions with estimated fees.
  - Supports Stellar testnet and mainnet configurations.

- **Bug Fixes**
  - Replaced the previous unimplemented deposit behavior with clear responses for authentication, validation, configuration, and service errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->