### PR TITLE
feat(middleware): add validateRequestSignature for cryptographic sign…

### DIFF
--- a/backend/src/lib/middleware/signature_validator.ts
+++ b/backend/src/lib/middleware/signature_validator.ts
@@ -1,0 +1,201 @@
+import { createHash } from "crypto";
+import { NextRequest, NextResponse } from "next/server";
+import { eq } from "drizzle-orm";
+import { Keypair } from "@stellar/stellar-sdk";
+import { getAuthPayload } from "@/lib/auth-session";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+
+// ─── Nonce Store ──────────────────────────────────────────────────────────────
+
+/**
+ * In-memory store for consumed request nonces.
+ * Prevents replay attacks within the 300-second signature validity window.
+ *
+ * Each entry maps a nonce string to its expiry timestamp (ms since epoch).
+ * Expired entries are lazily evicted on every read or write.
+ */
+class NonceStore {
+  private store = new Map<string, number>();
+
+  /** Removes all entries whose TTL has elapsed. */
+  private evict(): void {
+    const now = Date.now();
+    for (const [nonce, expiresAt] of this.store) {
+      if (now >= expiresAt) {
+        this.store.delete(nonce);
+      }
+    }
+  }
+
+  /**
+   * Returns `true` if the nonce is currently recorded (and not yet expired).
+   * Evicts stale entries before checking.
+   */
+  has(nonce: string): boolean {
+    this.evict();
+    return this.store.has(nonce);
+  }
+
+  /**
+   * Records a nonce with the given TTL in seconds.
+   * Evicts stale entries before storing.
+   */
+  set(nonce: string, ttlSeconds: number): void {
+    this.evict();
+    this.store.set(nonce, Date.now() + ttlSeconds * 1000);
+  }
+}
+
+const nonceStore = new NonceStore();
+
+// ─── Helper ───────────────────────────────────────────────────────────────────
+
+function sha256hex(input: string): string {
+  return createHash("sha256").update(input).digest("hex");
+}
+
+// ─── Main export ──────────────────────────────────────────────────────────────
+
+/**
+ * Validates the Ed25519 request signature supplied by the Stellar wallet owner.
+ *
+ * This middleware-style function is designed to be called at the top of a
+ * Next.js route handler.  It returns `null` when all checks pass (the caller
+ * should continue processing the request) or a `NextResponse` error when any
+ * check fails (the caller should return that response immediately).
+ *
+ * @example
+ * ```ts
+ * // In a route handler:
+ * // const sigError = await validateRequestSignature(request);
+ * // if (sigError) return sigError;
+ * ```
+ *
+ * ### Validation pipeline
+ * 1. Header presence (`x-signature`, `x-timestamp`)
+ * 2. Timestamp freshness (±300 s)
+ * 3. Authentication (`Authorization: Bearer <token>`)
+ * 4. Stellar public-key lookup from the database
+ * 5. Canonical payload construction and SHA-256 body hash
+ * 6. Ed25519 signature verification via the Stellar SDK
+ * 7. Nonce/replay-attack prevention (300 s TTL)
+ */
+export async function validateRequestSignature(
+  request: NextRequest,
+): Promise<NextResponse | null> {
+  // ── 1. Header extraction ─────────────────────────────────────────────────
+  const rawSignature = request.headers.get("x-signature") ?? "";
+  const rawTimestamp = request.headers.get("x-timestamp") ?? "";
+
+  if (!rawSignature) {
+    return NextResponse.json(
+      { error: "Missing X-Signature header" },
+      { status: 401 },
+    );
+  }
+
+  if (!rawTimestamp) {
+    return NextResponse.json(
+      { error: "Missing X-Timestamp header" },
+      { status: 401 },
+    );
+  }
+
+  // ── 2. Timestamp validation ──────────────────────────────────────────────
+  const ts = parseInt(rawTimestamp, 10);
+
+  if (!Number.isFinite(ts)) {
+    return NextResponse.json(
+      { error: "Invalid X-Timestamp value" },
+      { status: 400 },
+    );
+  }
+
+  if (Math.abs(Date.now() / 1000 - ts) > 300) {
+    return NextResponse.json(
+      { error: "Request timestamp expired" },
+      { status: 401 },
+    );
+  }
+
+  // ── 3. Auth check ────────────────────────────────────────────────────────
+  const authPayload = await getAuthPayload(request);
+  if (!authPayload) {
+    return NextResponse.json(
+      { error: "Unauthenticated request" },
+      { status: 401 },
+    );
+  }
+
+  const { userId } = authPayload;
+
+  // ── 4. Public key lookup ─────────────────────────────────────────────────
+  let stellarAddress: string | null;
+
+  try {
+    const [row] = await db
+      .select({ stellarAddress: users.stellarAddress })
+      .from(users)
+      .where(eq(users.id, userId));
+
+    stellarAddress = row?.stellarAddress ?? null;
+  } catch {
+    return NextResponse.json(
+      { error: "Internal error during key lookup" },
+      { status: 500 },
+    );
+  }
+
+  if (!stellarAddress) {
+    return NextResponse.json(
+      { error: "No public key on record for user" },
+      { status: 401 },
+    );
+  }
+
+  // ── 5. Signed payload construction ──────────────────────────────────────
+  const bodyText = await request.text();
+  const bodyHash = createHash("sha256").update(bodyText).digest("hex");
+  const pathname = new URL(request.url).pathname;
+  const payloadStr = `${ts}:${request.method.toUpperCase()}:${pathname}:${bodyHash}`;
+  const payloadBuffer = Buffer.from(payloadStr, "utf8");
+
+  // ── 6. Signature verification ────────────────────────────────────────────
+  const signatureBuffer = Buffer.from(rawSignature, "base64");
+
+  let verified: boolean;
+  try {
+    verified = Keypair.fromPublicKey(stellarAddress).verify(
+      payloadBuffer,
+      signatureBuffer,
+    );
+  } catch {
+    return NextResponse.json(
+      { error: "Signature verification failed" },
+      { status: 400 },
+    );
+  }
+
+  if (!verified) {
+    return NextResponse.json(
+      { error: "Invalid signature" },
+      { status: 401 },
+    );
+  }
+
+  // ── 7. Replay prevention ─────────────────────────────────────────────────
+  const nonce = `${userId}:${ts}:${sha256hex(rawSignature)}`;
+
+  if (nonceStore.has(nonce)) {
+    return NextResponse.json(
+      { error: "Duplicate request detected" },
+      { status: 401 },
+    );
+  }
+
+  nonceStore.set(nonce, 300);
+
+  // ── All checks passed ────────────────────────────────────────────────────
+  return null;
+}


### PR DESCRIPTION

# feat(middleware): add validateRequestSignature for cryptographic signature validation (#404)

## Description

Implements an Express-compatible middleware function `validateRequestSignature` at `backend/src/lib/middleware/signature_validator.ts` that protects sensitive wallet endpoints by verifying Ed25519 cryptographic signatures produced by the user's registered Stellar keypair. Invalid, expired, or replayed requests are rejected before reaching the route handler.

## How It Was Done

The middleware follows the existing codebase pattern — an async function that accepts a `NextRequest` and returns a `NextResponse` error or `null` (pass-through), callable directly inside route handlers.

The validation pipeline runs 7 sequential steps:

1. **Header extraction** — reads `X-Signature` and `X-Timestamp` from request headers; returns 401 if either is missing
2. **Timestamp validation** — parses the timestamp as a Unix integer and rejects requests outside a ±300 second window (401) or with a non-finite value (400)
3. **Auth check** — calls `getAuthPayload(request)` to extract the authenticated `userId` from the Bearer token; returns 401 if unauthenticated
4. **Public key lookup** — queries `users.stellarAddress` from the database using Drizzle ORM; returns 401 if no address is on record, 500 on DB error
5. **Signed payload construction** — builds a canonical string `{timestamp}:{METHOD}:{pathname}:{sha256(body)}` and encodes it as a UTF-8 buffer
6. **Signature verification** — decodes the base64 `X-Signature` and calls `Keypair.fromPublicKey(address).verify(payload, signature)` from `@stellar/stellar-sdk`; returns 401 on failure, 400 on a malformed key/signature
7. **Replay prevention** — derives a nonce as `{userId}:{timestamp}:{sha256(signature)}`, checks an in-memory `NonceStore` with a 300-second TTL, and rejects duplicate requests with 401

The `NonceStore` is a module-private singleton backed by a `Map<string, number>` (nonce → expiry ms) with lazy TTL eviction on every read and write to keep memory bounded.

Usage in a route handler:
```ts
const sigError = await validateRequestSignature(request);
if (sigError) return sigError;
closes #404

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security Enhancements**
  * Added request signature validation for Stellar wallet-owner requests.
  * Rejects missing, invalid, expired, or replayed signatures.
  * Verifies requests using authenticated sessions and the wallet’s public key.
  * Protects against tampered request bodies and unauthorized access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->