### PR TITLE
feat(repo): add Stellar address registration

### DIFF
--- a/mobile/lib/core/network/api_client.dart
+++ b/mobile/lib/core/network/api_client.dart
@@ -16,6 +16,7 @@ import 'api_exceptions.dart';
 class ApiClient {
   ApiClient({
     HttpClient? httpClient,
+    this.authTokenProvider,
     this.maxRetries = 3,
     this.baseDelay = const Duration(milliseconds: 500),
     this.maxDelay = const Duration(seconds: 4),
@@ -23,6 +24,9 @@ class ApiClient {
   }) : _httpClient = httpClient ?? HttpClient();
 
   final HttpClient _httpClient;
+
+  /// Provides the current access token for authenticated requests.
+  final Future<String?> Function()? authTokenProvider;
 
   /// Number of submission attempts before giving up.
   final int maxRetries;
@@ -103,6 +107,10 @@ class ApiClient {
     final uri = Uri.parse(url);
     final request = await _httpClient.postUrl(uri);
     request.headers.contentType = ContentType.json;
+    final token = await authTokenProvider?.call();
+    if (token != null && token.isNotEmpty) {
+      request.headers.set(HttpHeaders.authorizationHeader, 'Bearer $token');
+    }
     headers?.forEach((key, value) {
       request.headers.set(key, value);
     });
@@ -120,6 +128,12 @@ class ApiClient {
 
     if (statusCode == 400) {
       throw TransactionFailedException(
+        message,
+        statusCode: statusCode,
+      );
+    }
+    if (statusCode == 409) {
+      throw ConflictException(
         message,
         statusCode: statusCode,
       );

--- a/mobile/lib/core/network/api_exceptions.dart
+++ b/mobile/lib/core/network/api_exceptions.dart
@@ -33,6 +33,11 @@ class NetworkCongestedException extends ApiException {
   const NetworkCongestedException(super.message, {super.statusCode, super.cause});
 }
 
+/// Thrown when a resource conflicts with an existing registration (HTTP 409).
+class ConflictException extends ApiException {
+  const ConflictException(super.message, {super.statusCode, super.cause});
+}
+
 /// Thrown for any other unexpected API failure (e.g. HTTP 404, 422).
 class ApiRequestException extends ApiException {
   const ApiRequestException(super.message, {super.statusCode, super.cause});

--- a/mobile/lib/features/savings/data/savings_repository.dart
+++ b/mobile/lib/features/savings/data/savings_repository.dart
@@ -117,6 +117,21 @@ class SavingsRepository {
     submissionStatus.value = SavingsSubmissionStatus.idle;
   }
 
+  /// Registers a newly generated Stellar public key with the backend.
+  ///
+  /// Authentication is supplied by [ApiClient.authTokenProvider]. A duplicate
+  /// address is surfaced as [ConflictException] rather than being retried.
+  Future<void> registerStellarAddress(String stellarAddress) async {
+    if (stellarAddress.trim().isEmpty) {
+      throw ArgumentError.value(stellarAddress, 'stellarAddress', 'Cannot be empty.');
+    }
+
+    await _apiClient.postWithRetry(
+      '$_baseUrl/api/wallet/register',
+      {'stellarAddress': stellarAddress},
+    );
+  }
+
   Future<SavingsDataModel> fetchSavingsDashboardData(String accountId) async {
     // TODO: Call backend balance/apy endpoint via _apiClient.postWithRetry.
     return SavingsDataModel(balance: '0.0', apy: '0.0');

--- a/mobile/test/core/network/api_client_test.dart
+++ b/mobile/test/core/network/api_client_test.dart
@@ -109,6 +109,40 @@ void main() {
       client.close();
     });
 
+    test('adds a Bearer token from the auth provider', () async {
+      final (server, uri) = await startServer((request) async {
+        expect(request.headers.value(HttpHeaders.authorizationHeader), 'Bearer test-token');
+        return jsonResponse(request, 200, {'ok': true});
+      });
+      addTearDown(() => server.close(force: true));
+
+      final client = ApiClient(
+        authTokenProvider: () async => 'test-token',
+        baseDelay: const Duration(milliseconds: 1),
+      );
+      await client.postWithRetry(uri.toString(), const {});
+      client.close();
+    });
+
+    test('maps HTTP 409 to ConflictException without retrying', () async {
+      var attempts = 0;
+      final (server, uri) = await startServer((request) async {
+        attempts++;
+        return jsonResponse(request, 409, {'message': 'address already registered'});
+      });
+      addTearDown(() => server.close(force: true));
+
+      final client = ApiClient(maxRetries: 3, baseDelay: const Duration(milliseconds: 1));
+      await expectLater(
+        client.postWithRetry(uri.toString(), const {}),
+        throwsA(isA<ConflictException>()
+            .having((e) => e.statusCode, 'statusCode', 409)
+            .having((e) => e.message, 'message', 'address already registered')),
+      );
+      expect(attempts, 1);
+      client.close();
+    });
+
     test('maps other 4xx codes to ApiRequestException without retrying', () async {
       var attempts = 0;
       final (server, uri) = await startServer((request) async {

--- a/mobile/test/features/savings/data/savings_repository_test.dart
+++ b/mobile/test/features/savings/data/savings_repository_test.dart
@@ -36,6 +36,46 @@ Future<void> jsonResponse(HttpRequest request, int statusCode, Map<String, dynam
 }
 
 void main() {
+  group('SavingsRepository.registerStellarAddress', () {
+    test('posts the public key to the wallet registration endpoint', () async {
+      final (server, baseUri) = await startServer((request) async {
+        expect(request.uri.path, '/api/wallet/register');
+        final body = await utf8.decoder.bind(request).join();
+        expect(jsonDecode(body), {'stellarAddress': 'GABC'});
+        expect(request.headers.value(HttpHeaders.authorizationHeader), 'Bearer test-token');
+        return jsonResponse(request, 200, {'ok': true});
+      });
+      addTearDown(() => server.close(force: true));
+
+      final repository = SavingsRepository(
+        apiClient: ApiClient(
+          authTokenProvider: () async => 'test-token',
+          baseDelay: const Duration(milliseconds: 1),
+        ),
+        baseUrl: baseUri.toString(),
+      );
+
+      await repository.registerStellarAddress('GABC');
+    });
+
+    test('propagates duplicate address conflicts', () async {
+      final (server, baseUri) = await startServer((request) async {
+        return jsonResponse(request, 409, {'message': 'address already registered'});
+      });
+      addTearDown(() => server.close(force: true));
+
+      final repository = SavingsRepository(
+        apiClient: ApiClient(baseDelay: const Duration(milliseconds: 1)),
+        baseUrl: baseUri.toString(),
+      );
+
+      await expectLater(
+        repository.registerStellarAddress('GABC'),
+        throwsA(isA<ConflictException>()),
+      );
+    });
+  });
+
   group('SavingsRepository.submitSignedXdr', () {
     test('submits the signed XDR and reports succeeded state with the hash', () async {
       final (server, baseUri) = await startServer((request) async {

--- a/mobile/test/features/savings/savings_repository_test.dart
+++ b/mobile/test/features/savings/savings_repository_test.dart
@@ -4,8 +4,7 @@ import 'package:mobile/core/network/api_client.dart';
 import 'package:mobile/features/savings/data/savings_repository.dart';
 
 class _FakeApiClient extends ApiClient {
-  _FakeApiClient({this.response, this.error})
-      : super(baseUrl: 'https://example.test');
+  _FakeApiClient({this.response, this.error});
 
   final Map<String, dynamic>? response;
   final Object? error;
@@ -18,6 +17,7 @@ class _FakeApiClient extends ApiClient {
     String path,
     Map<String, dynamic> body, {
     int maxAttempts = 3,
+    Map<String, String>? headers,
   }) async {
     capturedPath = path;
     capturedBody = body;


### PR DESCRIPTION
## Summary

Before this change, the mobile savings repository had no onboarding API method for binding a user profile to a newly generated Stellar public key.

After this change:
* Added `SavingsRepository.registerStellarAddress(String stellarAddress)`.
* Sends the Stellar public key to `POST /api/wallet/register`.
* Added injectable access-token retrieval to `ApiClient`.
* Automatically includes the `Authorization: Bearer <token>` header.
* Added `ConflictException` handling for HTTP 409 duplicate-address responses.
* Added tests covering request payloads, authentication headers, successful registration, and duplicate-address conflicts.

## Verification

* `git diff --check` passed.
* Flutter analysis/tests could not run because Flutter and Dart are unavailable.
* Workspace tests could not run because Jest dependencies are unavailable (`jest: not found`).

Closes #396


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for authenticated API requests using bearer tokens.
  * Added the ability to register a Stellar address with the savings service.
  * Added clear handling for address-registration conflicts.

* **Bug Fixes**
  * HTTP 409 conflicts are now reported explicitly without unnecessary retries.

* **Tests**
  * Added coverage for authenticated requests, address registration, validation, and conflict responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->