### PR TITLE
Feat/Service to query on-chain vault balance

### DIFF
--- a/backend/__tests__/lib/defindexService.test.ts
+++ b/backend/__tests__/lib/defindexService.test.ts
@@ -623,3 +623,231 @@ describe("DefindexService.calculateDepositParams", () => {
     ).rejects.toMatchObject({ kind: "upstream" });
   });
 });
+
+describe("DefindexService.getVaultBalance", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    DefindexService.clearCache();
+    process.env.DEFINDEX_VAULT_CONTRACT_ID = VAULT_CONTRACT_ID;
+    process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+
+    mockSimulateTransaction.mockImplementation(async (tx: any) => {
+      switch (invokedMethod(tx)) {
+        case "balance_of":
+          return successResponse(nativeToScVal(BALANCE_OF, { type: "i128" }));
+        case "total_supply":
+          return successResponse(nativeToScVal(TOTAL_SUPPLY, { type: "i128" }));
+        case "fetch_total_managed_funds":
+          return successResponse(managedFundsResponse());
+        default:
+          throw new Error(`Unexpected contract method ${invokedMethod(tx)}`);
+      }
+    });
+  });
+
+  afterEach(() => {
+    DefindexService.clearCache();
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    delete process.env.SOROBAN_RPC_URL;
+  });
+
+  it("queries balance_of, total_supply, and managed_funds and calculates vault position and underlying USDC", async () => {
+    const result = await DefindexService.getVaultBalance(USER_ADDRESS);
+
+    expect(result.userAddress).toBe(USER_ADDRESS);
+    expect(result.contractId).toBe(VAULT_CONTRACT_ID);
+    expect(result.rawUserBalance).toBe(BALANCE_OF.toString());
+    expect(result.userBalance).toBe("0.0005000"); // 5,000 / 1e7
+    expect(result.rawSharePrice).toBe(EXPECTED_SHARE_PRICE.toString());
+    expect(result.sharePrice).toBe("1.0000000"); // 10_000_000_000 / 10_000 = 1,000,000 = 0.1 * 10^7 -> 1.0000000
+    // user owns 5,000 of 10,000 shares of 10_000_000_000 managed => 5_000_000_000 (500 USDC)
+    expect(result.rawUnderlyingUsdc).toBe("5000000000");
+    expect(result.underlyingUsdc).toBe("500.0000000");
+    expect(result.rawTotalSupply).toBe(TOTAL_SUPPLY.toString());
+    expect(result.rawTotalManagedFunds).toBe(TOTAL_MANAGED.toString());
+    expect(result.rpcUrl).toBe("https://fake-rpc.example.com");
+    expect(result.apy.rate).toBeNull();
+    expect(result.apy.formatted).toBe("N/A");
+    expect(result.apy.isEstimated).toBe(false);
+    expect(result.fetchedAt).toBeTruthy();
+  });
+
+  it("handles zero user share balance correctly", async () => {
+    mockSimulateTransaction.mockImplementation(async (tx: any) => {
+      switch (invokedMethod(tx)) {
+        case "balance_of":
+          return successResponse(nativeToScVal(0n, { type: "i128" }));
+        case "total_supply":
+          return successResponse(nativeToScVal(TOTAL_SUPPLY, { type: "i128" }));
+        case "fetch_total_managed_funds":
+          return successResponse(managedFundsResponse());
+        default:
+          throw new Error(`Unexpected contract method ${invokedMethod(tx)}`);
+      }
+    });
+
+    const result = await DefindexService.getVaultBalance(USER_ADDRESS);
+
+    expect(result.rawUserBalance).toBe("0");
+    expect(result.userBalance).toBe("0.0000000");
+    expect(result.rawUnderlyingUsdc).toBe("0");
+    expect(result.underlyingUsdc).toBe("0.0000000");
+  });
+
+  it("handles empty vault state (0 total supply, 0 managed funds) with 1:1 exchange rate fallback", async () => {
+    mockSimulateTransaction.mockImplementation(async (tx: any) => {
+      switch (invokedMethod(tx)) {
+        case "balance_of":
+          return successResponse(nativeToScVal(0n, { type: "i128" }));
+        case "total_supply":
+          return successResponse(nativeToScVal(0n, { type: "i128" }));
+        case "fetch_total_managed_funds":
+          return successResponse(managedFundsResponse(0n));
+        default:
+          throw new Error(`Unexpected contract method ${invokedMethod(tx)}`);
+      }
+    });
+
+    const result = await DefindexService.getVaultBalance(USER_ADDRESS);
+
+    expect(result.rawSharePrice).toBe("10000000"); // 10^7 = 1.0000000
+    expect(result.sharePrice).toBe("1.0000000");
+    expect(result.rawUnderlyingUsdc).toBe("0");
+  });
+
+  it("preserves large integer precision without JS float truncation", async () => {
+    const hugeBalance = 123_456_789_012_345_678n;
+    const hugeSupply = 200_000_000_000_000_000n;
+    const hugeManaged = 400_000_000_000_000_000n; // share price = 2 * 1e7
+
+    mockSimulateTransaction.mockImplementation(async (tx: any) => {
+      switch (invokedMethod(tx)) {
+        case "balance_of":
+          return successResponse(nativeToScVal(hugeBalance, { type: "i128" }));
+        case "total_supply":
+          return successResponse(nativeToScVal(hugeSupply, { type: "i128" }));
+        case "fetch_total_managed_funds":
+          return successResponse(managedFundsResponse(hugeManaged));
+        default:
+          throw new Error(`Unexpected contract method ${invokedMethod(tx)}`);
+      }
+    });
+
+    const result = await DefindexService.getVaultBalance(USER_ADDRESS);
+
+    expect(result.rawUserBalance).toBe(hugeBalance.toString());
+    const expectedUnderlying = (hugeBalance * hugeManaged) / hugeSupply;
+    expect(result.rawUnderlyingUsdc).toBe(expectedUnderlying.toString());
+  });
+
+  it("caches successful RPC responses and deduplicates repeated calls within TTL", async () => {
+    const first = await DefindexService.getVaultBalance(USER_ADDRESS);
+    const second = await DefindexService.getVaultBalance(USER_ADDRESS);
+
+    expect(second).toEqual(first);
+    // balance_of, total_supply, fetch_total_managed_funds called once
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(3);
+  });
+
+  it("bypasses cache when skipCache is true", async () => {
+    await DefindexService.getVaultBalance(USER_ADDRESS);
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(3);
+
+    await DefindexService.getVaultBalance(USER_ADDRESS, undefined, {
+      skipCache: true,
+    });
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(6);
+  });
+
+  it("expires cached entries after TTL", async () => {
+    await DefindexService.getVaultBalance(USER_ADDRESS, undefined, {
+      ttlMs: 50,
+    });
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(3);
+
+    await new Promise((resolve) => setTimeout(resolve, 60));
+
+    await DefindexService.getVaultBalance(USER_ADDRESS);
+    expect(mockSimulateTransaction).toHaveBeenCalledTimes(6);
+  });
+
+  it("calculates APY when a valid historical share price snapshot is provided", async () => {
+    // Current share price: 10_000_000 (1.0000000)
+    // Snapshot from 30 days ago (30 * 86400 seconds) with share price 9_500_000
+    const pastTimestamp = Math.floor(Date.now() / 1000) - 30 * 86400;
+    const pastSharePrice = 9_500_000n;
+
+    const result = await DefindexService.getVaultBalance(USER_ADDRESS, undefined, {
+      historicalSnapshot: {
+        timestamp: pastTimestamp,
+        sharePrice: pastSharePrice.toString(),
+      },
+    });
+
+    expect(result.apy.isEstimated).toBe(true);
+    expect(result.apy.rate).toBeGreaterThan(0);
+    expect(result.apy.formatted).toMatch(/^[0-9]+\.[0-9]{2}%$/);
+    expect(result.apy.methodology).toContain("Annualized return derived from historical share price increase");
+  });
+
+  it("returns APY rate null when historical snapshot is missing or elapsed time is under 1 hour", async () => {
+    const recentTimestamp = Math.floor(Date.now() / 1000) - 60; // 1 min ago
+    const result = await DefindexService.getVaultBalance(USER_ADDRESS, undefined, {
+      historicalSnapshot: {
+        timestamp: recentTimestamp,
+        sharePrice: "9500000",
+      },
+    });
+
+    expect(result.apy.rate).toBeNull();
+    expect(result.apy.formatted).toBe("N/A");
+    expect(result.apy.isEstimated).toBe(false);
+  });
+
+  it("throws validation error for an invalid user address", async () => {
+    await expect(
+      DefindexService.getVaultBalance("not-a-valid-stellar-key"),
+    ).rejects.toMatchObject({ kind: "validation" });
+  });
+
+  it("throws configuration error when DEFINDEX_VAULT_CONTRACT_ID is not set", async () => {
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+
+    await expect(
+      DefindexService.getVaultBalance(USER_ADDRESS),
+    ).rejects.toMatchObject({ kind: "configuration" });
+  });
+
+  it("throws upstream error on Soroban RPC failure and does not cache the error", async () => {
+    mockSimulateTransaction.mockRejectedValue(new Error("RPC unavailable"));
+
+    await expect(
+      DefindexService.getVaultBalance(USER_ADDRESS),
+    ).rejects.toMatchObject({ kind: "upstream" });
+
+    // Cache should remain empty
+    mockSimulateTransaction.mockImplementation(async (tx: any) => {
+      switch (invokedMethod(tx)) {
+        case "balance_of":
+          return successResponse(nativeToScVal(BALANCE_OF, { type: "i128" }));
+        case "total_supply":
+          return successResponse(nativeToScVal(TOTAL_SUPPLY, { type: "i128" }));
+        case "fetch_total_managed_funds":
+          return successResponse(managedFundsResponse());
+        default:
+          throw new Error(`Unexpected contract method ${invokedMethod(tx)}`);
+      }
+    });
+
+    const result = await DefindexService.getVaultBalance(USER_ADDRESS);
+    expect(result.rawUserBalance).toBe(BALANCE_OF.toString());
+  });
+
+  it("supports getVaultPosition alias", async () => {
+    const result = await DefindexService.getVaultPosition(USER_ADDRESS);
+    expect(result.userAddress).toBe(USER_ADDRESS);
+    expect(result.rawUserBalance).toBe(BALANCE_OF.toString());
+  });
+});
+

--- a/backend/__tests__/lib/defindexService.test.ts
+++ b/backend/__tests__/lib/defindexService.test.ts
@@ -660,7 +660,7 @@ describe("DefindexService.getVaultBalance", () => {
     expect(result.rawUserBalance).toBe(BALANCE_OF.toString());
     expect(result.userBalance).toBe("0.0005000"); // 5,000 / 1e7
     expect(result.rawSharePrice).toBe(EXPECTED_SHARE_PRICE.toString());
-    expect(result.sharePrice).toBe("1.0000000"); // 10_000_000_000 / 10_000 = 1,000,000 = 0.1 * 10^7 -> 1.0000000
+    expect(result.sharePrice).toBe("1000000.0000000");
     // user owns 5,000 of 10,000 shares of 10_000_000_000 managed => 5_000_000_000 (500 USDC)
     expect(result.rawUnderlyingUsdc).toBe("5000000000");
     expect(result.underlyingUsdc).toBe("500.0000000");
@@ -773,10 +773,10 @@ describe("DefindexService.getVaultBalance", () => {
   });
 
   it("calculates APY when a valid historical share price snapshot is provided", async () => {
-    // Current share price: 10_000_000 (1.0000000)
-    // Snapshot from 30 days ago (30 * 86400 seconds) with share price 9_500_000
+    // Current share price: EXPECTED_SHARE_PRICE (10_000_000_000_000n)
+    // Snapshot from 30 days ago with share price 5% lower (9_500_000_000_000n)
     const pastTimestamp = Math.floor(Date.now() / 1000) - 30 * 86400;
-    const pastSharePrice = 9_500_000n;
+    const pastSharePrice = (EXPECTED_SHARE_PRICE * 95n) / 100n;
 
     const result = await DefindexService.getVaultBalance(USER_ADDRESS, undefined, {
       historicalSnapshot: {
@@ -793,10 +793,11 @@ describe("DefindexService.getVaultBalance", () => {
 
   it("returns APY rate null when historical snapshot is missing or elapsed time is under 1 hour", async () => {
     const recentTimestamp = Math.floor(Date.now() / 1000) - 60; // 1 min ago
+    const pastSharePrice = (EXPECTED_SHARE_PRICE * 95n) / 100n;
     const result = await DefindexService.getVaultBalance(USER_ADDRESS, undefined, {
       historicalSnapshot: {
         timestamp: recentTimestamp,
-        sharePrice: "9500000",
+        sharePrice: pastSharePrice.toString(),
       },
     });
 

--- a/backend/src/lib/services/defindex_service.ts
+++ b/backend/src/lib/services/defindex_service.ts
@@ -22,6 +22,80 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
+/** Details about the yield / APY estimate for a vault position. */
+export interface APYInfo {
+  /**
+   * Annualized yield rate as a float (e.g. 0.0825 for 8.25%),
+   * or `null` if insufficient historical data exists to calculate a meaningful APY.
+   */
+  rate: number | null;
+  /** Formatted APY percentage string (e.g. "8.25%" or "N/A"). */
+  formatted: string;
+  /** True if this APY is an estimate calculated from historical share price changes. */
+  isEstimated: boolean;
+  /** Description of the methodology used to derive or evaluate the APY. */
+  methodology: string;
+  /** Optional realized yield in USDC over the elapsed period if calculated against a user deposit. */
+  realizedYieldUsdc?: string | null;
+}
+
+/** Historical share price snapshot used to calculate realized yield / APY. */
+export interface HistoricalSharePriceSnapshot {
+  /** Timestamp in seconds (Unix epoch), ISO date string, or Date of historical snapshot. */
+  timestamp: number | string | Date;
+  /** Historical share price (scaled by 10^7, as a string or bigint). */
+  sharePrice: string | bigint;
+}
+
+/** Options for querying a vault position / balance. */
+export interface GetVaultBalanceOptions {
+  /** Override default vault contract ID. */
+  vaultContractId?: string;
+  /** Override default RPC URL. */
+  rpcUrl?: string;
+  /** Override default network passphrase. */
+  networkPassphrase?: string;
+  /** Bypass in-memory cache and perform a fresh RPC query. */
+  skipCache?: boolean;
+  /** Cache TTL in milliseconds for this request (default: 10,000ms / 10s). */
+  ttlMs?: number;
+  /** Historical share price snapshot for APY calculation. */
+  historicalSnapshot?: HistoricalSharePriceSnapshot;
+}
+
+/** Results of a DeFindex vault balance / position query. */
+export interface VaultBalance {
+  /** Stellar address of the user. */
+  userAddress: string;
+  /** DeFindex vault contract ID. */
+  contractId: string;
+  /** User's raw vault share balance in smallest units (i128, 7 decimals). */
+  rawUserBalance: string;
+  /** User's normalized vault share balance (decimal string, e.g. "5000.0000000"). */
+  userBalance: string;
+  /** Current share price scaled by 10^7 (matches USDC / share precision). */
+  rawSharePrice: string;
+  /** Current share price normalized (decimal string, e.g. "1.0000000"). */
+  sharePrice: string;
+  /** User's underlying USDC-equivalent position in smallest units (i128, 7 decimals). */
+  rawUnderlyingUsdc: string;
+  /** User's underlying USDC-equivalent position normalized (decimal string, e.g. "500.0000000"). */
+  underlyingUsdc: string;
+  /** Total vault share supply in smallest units (i128). */
+  rawTotalSupply: string;
+  /** Total USDC managed by the vault in smallest units (i128). */
+  rawTotalManagedFunds: string;
+  /** Soroban RPC endpoint used. */
+  rpcUrl: string;
+  /** Yield / APY estimation details. */
+  apy: APYInfo;
+  /** ISO timestamp when the position was fetched. */
+  fetchedAt: string;
+}
+
+/** Alias for VaultBalance for callers using position terminology. */
+export type VaultPosition = VaultBalance;
+
 /** Results of a DeFindex deposit parameter calculation. */
 export interface DepositParams {
   userAddress: string;
@@ -93,7 +167,304 @@ export class DefindexServiceError extends Error {
   }
 }
 
+/**
+ * Formats a raw integer bigint into a decimal string without floating point loss.
+ * E.g., formatUnits(12345678n, 7) => "1.2345678"
+ */
+export function formatUnits(value: bigint, decimals: number = 7): string {
+  const isNegative = value < 0n;
+  const abs = isNegative ? -value : value;
+  const str = abs.toString().padStart(decimals + 1, "0");
+  const integerPart = str.slice(0, str.length - decimals);
+  const fractionalPart = str.slice(str.length - decimals);
+  return `${isNegative ? "-" : ""}${integerPart}.${fractionalPart}`;
+}
+
+interface CacheEntry<T> {
+  data: T;
+  expiresAt: number;
+}
+
+class DefindexCache {
+  private cache = new Map<string, CacheEntry<unknown>>();
+  private pendingPromises = new Map<string, Promise<unknown>>();
+  private defaultTtlMs = 10_000;
+
+  get<T>(key: string): T | undefined {
+    const entry = this.cache.get(key);
+    if (!entry) return undefined;
+    if (Date.now() > entry.expiresAt) {
+      this.cache.delete(key);
+      return undefined;
+    }
+    return entry.data as T;
+  }
+
+  set<T>(key: string, data: T, ttlMs?: number): void {
+    const ttl = ttlMs ?? this.defaultTtlMs;
+    this.cache.set(key, {
+      data,
+      expiresAt: Date.now() + ttl,
+    });
+  }
+
+  async getOrFetch<T>(
+    key: string,
+    fetcher: () => Promise<T>,
+    skipCache: boolean = false,
+    ttlMs?: number,
+  ): Promise<T> {
+    if (!skipCache) {
+      const cached = this.get<T>(key);
+      if (cached !== undefined) {
+        return cached;
+      }
+      const pending = this.pendingPromises.get(key);
+      if (pending) {
+        return pending as Promise<T>;
+      }
+    }
+
+    const promise = (async () => {
+      try {
+        const data = await fetcher();
+        if (!skipCache) {
+          this.set(key, data, ttlMs);
+        }
+        return data;
+      } finally {
+        this.pendingPromises.delete(key);
+      }
+    })();
+
+    this.pendingPromises.set(key, promise);
+    return promise;
+  }
+
+  clear(): void {
+    this.cache.clear();
+    this.pendingPromises.clear();
+  }
+}
+
+const defindexCacheSingleton = new DefindexCache();
+
 export class DefindexService {
+  /**
+   * Queries a user's DeFindex vault position on Soroban, including user share balance,
+   * share price, underlying USDC balance, and APY/yield estimate.
+   *
+   * Utilizes a short-lived in-memory cache to deduplicate repeated RPC calls.
+   *
+   * @param userAddress Stellar G... public key of the user.
+   * @param vaultContractId Optional contract address (defaults to DEFINDEX_VAULT_CONTRACT_ID env var).
+   * @param options Additional query options (caching, RPC URL, historical snapshot for APY).
+   */
+  static async getVaultBalance(
+    userAddress: string,
+    vaultContractId?: string,
+    options?: GetVaultBalanceOptions,
+  ): Promise<VaultBalance> {
+    const contractId =
+      vaultContractId || options?.vaultContractId || process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    const rpcUrl =
+      options?.rpcUrl || process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
+    const networkPassphrase =
+      options?.networkPassphrase || process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
+
+    if (!StrKey.isValidEd25519PublicKey(userAddress)) {
+      throw new DefindexServiceError(
+        `Invalid user address "${userAddress}": expected a valid Stellar G... public key`,
+        "validation",
+      );
+    }
+
+    if (!contractId || !StrKey.isValidContract(contractId)) {
+      throw new DefindexServiceError(
+        "DEFINDEX_VAULT_CONTRACT_ID is not configured: expected a valid Stellar C... contract address",
+        "configuration",
+      );
+    }
+
+    const cacheKey = `${contractId}:${userAddress}`;
+
+    return defindexCacheSingleton.getOrFetch(
+      cacheKey,
+      async () => {
+        const server = new rpc.Server(rpcUrl);
+
+        try {
+          const userAddressScVal = Address.fromString(userAddress).toScVal();
+
+          const userBalanceRaw = BigInt(
+            scValToNative(
+              await DefindexService.queryVault(
+                server,
+                contractId,
+                "balance_of",
+                [userAddressScVal],
+                userAddress,
+                networkPassphrase,
+              ),
+            ) as bigint,
+          );
+
+          const totalSupplyRaw = BigInt(
+            scValToNative(
+              await DefindexService.queryVault(
+                server,
+                contractId,
+                "total_supply",
+                [],
+                userAddress,
+                networkPassphrase,
+              ),
+            ) as bigint,
+          );
+
+          const managedFunds = scValToNative(
+            await DefindexService.queryVault(
+              server,
+              contractId,
+              "fetch_total_managed_funds",
+              [],
+              userAddress,
+              networkPassphrase,
+            ),
+          ) as Array<{
+            asset: string;
+            total_amount: bigint;
+            idle_amount: bigint;
+            invested_amount: bigint;
+            strategy_allocations: unknown[];
+          }>;
+
+          if (managedFunds.length === 0) {
+            throw new DefindexServiceError(
+              `Vault ${contractId} reports no managed assets; cannot calculate vault balance`,
+              "upstream",
+            );
+          }
+
+          const totalManagedFundsRaw = managedFunds.reduce(
+            (sum, asset) => sum + BigInt(asset.total_amount),
+            0n,
+          );
+
+          if (totalSupplyRaw <= 0n && totalManagedFundsRaw > 0n) {
+            throw new DefindexServiceError(
+              `Vault ${contractId} manages ${totalManagedFundsRaw} units but has no shares in circulation; cannot calculate position`,
+              "upstream",
+            );
+          }
+
+          if (totalManagedFundsRaw <= 0n && totalSupplyRaw > 0n) {
+            throw new DefindexServiceError(
+              `Vault ${contractId} has shares in circulation but manages no USDC funds; cannot calculate position`,
+              "upstream",
+            );
+          }
+
+          let sharePriceRaw: bigint;
+          let underlyingUsdcRaw: bigint;
+
+          if (totalSupplyRaw <= 0n) {
+            sharePriceRaw = 10n ** 7n;
+            underlyingUsdcRaw = userBalanceRaw;
+          } else {
+            sharePriceRaw = (totalManagedFundsRaw * 10n ** 7n) / totalSupplyRaw;
+            underlyingUsdcRaw = (userBalanceRaw * totalManagedFundsRaw) / totalSupplyRaw;
+          }
+
+          let apy: APYInfo = {
+            rate: null,
+            formatted: "N/A",
+            isEstimated: false,
+            methodology:
+              "Historical vault performance data is insufficient or unavailable to calculate a meaningful APY.",
+          };
+
+          if (options?.historicalSnapshot) {
+            const snap = options.historicalSnapshot;
+            const pastTime =
+              typeof snap.timestamp === "number"
+                ? snap.timestamp
+                : snap.timestamp instanceof Date
+                ? Math.floor(snap.timestamp.getTime() / 1000)
+                : Math.floor(new Date(snap.timestamp).getTime() / 1000);
+            const currentTime = Math.floor(Date.now() / 1000);
+            const elapsedSeconds = currentTime - pastTime;
+
+            const pastSharePriceRaw = BigInt(snap.sharePrice);
+
+            if (
+              elapsedSeconds >= 3600 &&
+              pastSharePriceRaw > 0n &&
+              sharePriceRaw >= pastSharePriceRaw
+            ) {
+              const ratio = Number(sharePriceRaw) / Number(pastSharePriceRaw);
+              const years = elapsedSeconds / (365.25 * 86400);
+              const annualizedRate = Math.pow(ratio, 1 / years) - 1;
+
+              if (Number.isFinite(annualizedRate) && annualizedRate >= 0) {
+                const percentageStr = (annualizedRate * 100).toFixed(2) + "%";
+                apy = {
+                  rate: annualizedRate,
+                  formatted: percentageStr,
+                  isEstimated: true,
+                  methodology: `Annualized return derived from historical share price increase over ${Math.round(
+                    elapsedSeconds / 3600,
+                  )} hours.`,
+                };
+              }
+            }
+          }
+
+          return {
+            userAddress,
+            contractId,
+            rawUserBalance: userBalanceRaw.toString(),
+            userBalance: formatUnits(userBalanceRaw, 7),
+            rawSharePrice: sharePriceRaw.toString(),
+            sharePrice: formatUnits(sharePriceRaw, 7),
+            rawUnderlyingUsdc: underlyingUsdcRaw.toString(),
+            underlyingUsdc: formatUnits(underlyingUsdcRaw, 7),
+            rawTotalSupply: totalSupplyRaw.toString(),
+            rawTotalManagedFunds: totalManagedFundsRaw.toString(),
+            rpcUrl,
+            apy,
+            fetchedAt: new Date().toISOString(),
+          };
+        } catch (error) {
+          if (error instanceof DefindexServiceError) {
+            throw error;
+          }
+          const err = error instanceof Error ? error : new Error(String(error));
+          throw new DefindexServiceError(
+            `Failed to query DeFindex vault balance for ${userAddress}: ${err.message}`,
+            "upstream",
+            err,
+          );
+        }
+      },
+      options?.skipCache,
+      options?.ttlMs,
+    );
+  }
+
+  /** Alias for getVaultBalance for callers using position terminology. */
+  static async getVaultPosition(
+    userAddress: string,
+    vaultContractId?: string,
+    options?: GetVaultBalanceOptions,
+  ): Promise<VaultBalance> {
+    return DefindexService.getVaultBalance(userAddress, vaultContractId, options);
+  }
+
+  /** Clears the internal RPC response cache (useful for testing and manual invalidation). */
+  static clearCache(): void {
+    defindexCacheSingleton.clear();
+  }
   /**
    * Calculates the Soroban parameters required to withdraw `amount` of USDC
    * from the DeFindex vault on behalf of `userAddress` and returns an

--- a/backend/src/lib/services/defindex_service.ts
+++ b/backend/src/lib/services/defindex_service.ts
@@ -286,7 +286,10 @@ export class DefindexService {
       );
     }
 
-    const cacheKey = `${contractId}:${userAddress}`;
+    const snapKey = options?.historicalSnapshot
+      ? `:${options.historicalSnapshot.timestamp}:${options.historicalSnapshot.sharePrice}`
+      : "";
+    const cacheKey = `${contractId}:${userAddress}:${rpcUrl}:${networkPassphrase}${snapKey}`;
 
     return defindexCacheSingleton.getOrFetch(
       cacheKey,

--- a/backend/tsconfig.json
+++ b/backend/tsconfig.json
@@ -13,8 +13,7 @@
     "paths": {
       "@/app/api/*": ["./src/api/*"],
       "@/*": ["./src/*"]
-    },
-    "types": ["node", "jest"]
+    }
   },
   "include": ["src/**/*", "__tests__/**/*"],
   "exclude": ["node_modules", "dist"]

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -7704,8 +7704,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.2
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -7727,7 +7727,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7738,22 +7738,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7764,7 +7764,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,7 @@
     "paths": {
       "@/app/api/*": ["./src/api/*"],
       "@/*": ["./src/*"]
-    },
-    "types": ["node", "jest"]
+    }
   },
   "include": [
     "backend/src/**/*",


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of what was worked on. -->
Implemented the DeFindex on-chain vault balance query service in `backend/src/lib/services/defindex_service.ts`. This service queries a user's vault share balance from Soroban RPC, converts vault shares into their underlying USDC value, calculates/exposes yield and APY estimates when historical data is available, and incorporates a short-lived in-memory cache to deduplicate repeated RPC calls.

## How It Was Done
<!-- Explain the technical implementation or approach used to solve the problem. -->
- **Service Methods**: Added `DefindexService.getVaultBalance(userAddress, vaultContractId?, options?)` and `DefindexService.getVaultPosition(...)` alias.
- **Soroban State Queries**: Invoked `balance_of`, `total_supply`, and `fetch_total_managed_funds` on the vault contract via `DefindexService.queryVault` using `@stellar/stellar-sdk` RPC Server.
- **Share to USDC Conversion**: Derived exchange rate `(totalManagedFunds * 10^7) / totalSupply` and user USDC balance `(userBalance * totalManagedFunds) / totalSupply`. Implemented `formatUnits` helper to format 128-bit integers as decimal strings without floating-point precision loss. Handled zero share supply / empty vault state with 1:1 fallback.
- **Yield / APY Estimation**: Added annualized yield calculation when historical share price snapshot options are provided:
  \[ \text{APY} = \left(\frac{\text{currentSharePrice}}{\text{pastSharePrice}}\right)^{\frac{365.25 \times 86400}{\text{elapsedSeconds}}} - 1 \]
  Returns `rate: null` and `formatted: "N/A"` when snapshot data is unavailable to prevent fabricating APY figures.
- **Short-Lived RPC Caching**: Created `DefindexCache` singleton with a 10-second default TTL, in-flight request deduplication, cache bypass (`skipCache: true`), and cache clearing (`DefindexService.clearCache()`).

## Issues Encountered (If Any)
<!-- Detail any blockers, issues, or tricky parts you encountered while working on this PR. -->
- In pnpm monorepos, explicitly specifying `"types": ["node", "jest"]` or `typeRoots` in `tsconfig.json` caused TypeScript compiler warnings (`TS2688: Cannot find type definition file for 'jest'`). Resolved by removing explicit types in `tsconfig.json` so TypeScript auto-discovers packages in pnpm's hoisted `@types` structure.

## Related Issue
<!-- Use the "Closes #issue-number" format to automatically link and close the issue. -->
Closes #413 

## How It Was Tested
<!-- Describe the tests that you ran to verify your changes, or how the reviewer can test them locally. -->
- Added 13 new unit tests in `backend/__tests__/lib/defindexService.test.ts` covering non-zero share balances, zero share balances, empty vault state, precision with 18+ digit integers, RPC response caching, cache bypass/expiry, APY estimation with historical snapshots vs missing snapshots, and validation/configuration/upstream error handling.
- Ran all 49 backend unit tests via `npx jest`: **49/49 passed**.
- Ran `pnpm --filter zendvo-backend build` and `npx tsc --noEmit`: **0 errors**.


## Screenshots / Video (If Applicable)
<!-- Include screenshots or videos to visually demonstrate your changes if you modified the UI. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added vault balance and position tracking.
  - Displays user balances, share prices, underlying USDC value, and optional estimated APY.
  - Supports precise large-value calculations and efficient cached responses.

- **Bug Fixes**
  - Improved handling of empty vaults and zero balances.
  - Added clearer validation, configuration, and upstream error reporting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->