### PR TITLE
feat(backend): integrate DeFindex server SDK for vault queries and invocations

### DIFF
--- a/backend/__tests__/api/wallet/deposit.test.ts
+++ b/backend/__tests__/api/wallet/deposit.test.ts
@@ -5,6 +5,16 @@ import { DefindexService, DefindexServiceError } from "@/lib/services/defindex_s
 
 const VALID_STELLAR_ADDRESS = "GDWF77422SKLZTBQT77BQEQLCIQY6PFTFZX5OFJTLAFFWJ2PK5WBOZAN";
 
+jest.mock("@defindex/sdk", () => ({
+  DefindexSDK: jest.fn().mockImplementation(() => ({
+    getVaultInfo: jest.fn(),
+    getVaultAPY: jest.fn(),
+    depositToVault: jest.fn(),
+    withdrawFromVault: jest.fn(),
+  })),
+  SupportedNetworks: { TESTNET: "testnet", MAINNET: "mainnet" },
+}));
+
 jest.mock("@/lib/auth-session", () => ({
   getAuthPayload: jest.fn(),
 }));

--- a/backend/__tests__/lib/defindexService.test.ts
+++ b/backend/__tests__/lib/defindexService.test.ts
@@ -12,12 +12,36 @@ import {
   DefindexServiceError,
 } from "../../src/lib/services/defindex_service";
 
+jest.mock("@defindex/sdk", () => {
+  const mockGetVaultInfo = jest.fn();
+  const mockGetVaultAPY = jest.fn();
+  const mockDepositToVault = jest.fn();
+  const mockWithdrawFromVault = jest.fn();
+  const MockDefindexSDK = jest.fn().mockImplementation(() => ({
+    getVaultInfo: mockGetVaultInfo,
+    getVaultAPY: mockGetVaultAPY,
+    depositToVault: mockDepositToVault,
+    withdrawFromVault: mockWithdrawFromVault,
+  }));
+  return {
+    DefindexSDK: MockDefindexSDK,
+    SupportedNetworks: { TESTNET: "testnet", MAINNET: "mainnet" },
+    __mockGetVaultInfo: mockGetVaultInfo,
+    __mockGetVaultAPY: mockGetVaultAPY,
+    __mockDepositToVault: mockDepositToVault,
+    __mockWithdrawFromVault: mockWithdrawFromVault,
+    __MockDefindexSDK: MockDefindexSDK,
+  };
+});
+
 jest.mock("@stellar/stellar-sdk", () => {
   const actual = jest.requireActual("@stellar/stellar-sdk");
   const mockSimulateTransaction = jest.fn();
+  const mockGetHealth = jest.fn();
   class MockServer {
     url: string;
     simulateTransaction = mockSimulateTransaction;
+    getHealth = mockGetHealth;
 
     constructor(url: string) {
       this.url = url;
@@ -30,11 +54,24 @@ jest.mock("@stellar/stellar-sdk", () => {
       Server: MockServer,
     },
     __mockSimulateTransaction: mockSimulateTransaction,
+    __mockGetHealth: mockGetHealth,
   };
 });
 
 const mockSimulateTransaction = (require("@stellar/stellar-sdk") as any)
   .__mockSimulateTransaction as jest.Mock;
+const mockGetHealth = (require("@stellar/stellar-sdk") as any)
+  .__mockGetHealth as jest.Mock;
+const mockGetVaultInfo = (require("@defindex/sdk") as any)
+  .__mockGetVaultInfo as jest.Mock;
+const mockGetVaultAPY = (require("@defindex/sdk") as any)
+  .__mockGetVaultAPY as jest.Mock;
+const mockDepositToVault = (require("@defindex/sdk") as any)
+  .__mockDepositToVault as jest.Mock;
+const mockWithdrawFromVault = (require("@defindex/sdk") as any)
+  .__mockWithdrawFromVault as jest.Mock;
+const MockDefindexSDK = (require("@defindex/sdk") as any)
+  .__MockDefindexSDK as jest.Mock;
 
 // ── Fixtures ────────────────────────────────────────────────────────────────
 const VAULT_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 7));
@@ -108,6 +145,7 @@ describe("DefindexService.calculateWithdrawalParams", () => {
     process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
     delete process.env.STELLAR_NETWORK_PASSPHRASE;
 
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
     mockSimulateTransaction.mockImplementation(async (tx: any) => {
       switch (invokedMethod(tx)) {
         case "balance_of":
@@ -356,6 +394,7 @@ describe("DefindexService.calculateDepositParams", () => {
     process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
     delete process.env.STELLAR_NETWORK_PASSPHRASE;
 
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
     mockSimulateTransaction.mockImplementation(async (tx: any) => {
       switch (invokedMethod(tx)) {
         case "total_supply":
@@ -623,3 +662,298 @@ describe("DefindexService.calculateDepositParams", () => {
     ).rejects.toMatchObject({ kind: "upstream" });
   });
 });
+
+describe("DefindexService SDK initialization", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DEFINDEX_VAULT_CONTRACT_ID = VAULT_CONTRACT_ID;
+    process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
+    process.env.DEFINDEX_API_KEY = "sk_test_key";
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
+  });
+
+  afterEach(() => {
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    delete process.env.SOROBAN_RPC_URL;
+    delete process.env.DEFINDEX_API_KEY;
+  });
+
+  it("creates an SDK client configured with the RPC URL and network passphrase", () => {
+    const client = DefindexService.createClient();
+
+    expect(client.rpcUrl).toBe("https://fake-rpc.example.com");
+    expect(client.networkPassphrase).toBe(
+      "Test SDF Network ; September 2015",
+    );
+    expect(client.network).toBe("testnet");
+    expect(client.sdk).toBeDefined();
+    expect(client.server).toBeDefined();
+    expect(MockDefindexSDK).toHaveBeenCalledWith(
+      expect.objectContaining({
+        apiKey: "sk_test_key",
+        defaultNetwork: "testnet",
+        timeout: 30_000,
+      }),
+    );
+  });
+
+  it("maps the public network passphrase to mainnet", () => {
+    process.env.STELLAR_NETWORK_PASSPHRASE =
+      "Public Global Stellar Network ; September 2015";
+
+    const client = DefindexService.createClient();
+
+    expect(client.network).toBe("mainnet");
+    expect(client.networkPassphrase).toBe(
+      "Public Global Stellar Network ; September 2015",
+    );
+  });
+
+  it("verifies RPC connectivity on initialize", async () => {
+    const client = await DefindexService.initialize();
+
+    expect(mockGetHealth).toHaveBeenCalledTimes(1);
+    expect(client.rpcUrl).toBe("https://fake-rpc.example.com");
+  });
+
+  it("wraps RPC connectivity failures as upstream errors", async () => {
+    mockGetHealth.mockRejectedValue(new Error("ECONNREFUSED"));
+
+    await expect(DefindexService.initialize()).rejects.toThrow(
+      DefindexServiceError,
+    );
+    await expect(DefindexService.initialize()).rejects.toThrow(
+      /Failed to connect to Soroban RPC at https:\/\/fake-rpc.example.com/,
+    );
+    await expect(DefindexService.initialize()).rejects.toMatchObject({
+      kind: "upstream",
+    });
+  });
+
+  it("wraps SDK constructor failures as upstream errors", () => {
+    MockDefindexSDK.mockImplementationOnce(() => {
+      throw new Error("invalid config");
+    });
+
+    expect(() => DefindexService.createClient()).toThrow(DefindexServiceError);
+    expect(() => {
+      MockDefindexSDK.mockImplementationOnce(() => {
+        throw new Error("invalid config");
+      });
+      DefindexService.createClient();
+    }).toThrow(/Failed to initialize DeFindex SDK/);
+  });
+});
+
+describe("DefindexService.queryVaultInfo", () => {
+  const vaultInfo = {
+    name: "Zendvo USDC Vault",
+    symbol: "zUSDC",
+    roles: {
+      emergencyManager: USER_ADDRESS,
+      rebalanceManager: USER_ADDRESS,
+      feeReceiver: USER_ADDRESS,
+      manager: USER_ADDRESS,
+    },
+    assets: [],
+    totalManagedFunds: [],
+    feesBps: { vaultFee: 100, defindexFee: 50 },
+    apy: 4.2,
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DEFINDEX_VAULT_CONTRACT_ID = VAULT_CONTRACT_ID;
+    process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
+    mockGetVaultInfo.mockResolvedValue(vaultInfo);
+  });
+
+  afterEach(() => {
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    delete process.env.SOROBAN_RPC_URL;
+  });
+
+  it("returns vault parameters from the DeFindex SDK", async () => {
+    const result = await DefindexService.queryVaultInfo();
+
+    expect(result).toEqual(vaultInfo);
+    expect(mockGetVaultInfo).toHaveBeenCalledWith(VAULT_CONTRACT_ID, "testnet");
+  });
+
+  it("queries a caller-supplied vault address", async () => {
+    const otherVault = StrKey.encodeContract(Buffer.alloc(32, 9));
+    await DefindexService.queryVaultInfo(otherVault);
+
+    expect(mockGetVaultInfo).toHaveBeenCalledWith(otherVault, "testnet");
+  });
+
+  it("throws when the vault contract id is not configured", async () => {
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    await expect(DefindexService.queryVaultInfo()).rejects.toThrow(
+      /DEFINDEX_VAULT_CONTRACT_ID/,
+    );
+  });
+
+  it("wraps SDK failures as upstream errors", async () => {
+    mockGetVaultInfo.mockRejectedValue(new Error("api down"));
+
+    await expect(DefindexService.queryVaultInfo()).rejects.toThrow(
+      DefindexServiceError,
+    );
+    await expect(DefindexService.queryVaultInfo()).rejects.toMatchObject({
+      kind: "upstream",
+    });
+  });
+});
+
+describe("DefindexService.estimateApy", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DEFINDEX_VAULT_CONTRACT_ID = VAULT_CONTRACT_ID;
+    process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
+    mockGetVaultAPY.mockResolvedValue({ apy: 5.5 });
+  });
+
+  afterEach(() => {
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    delete process.env.SOROBAN_RPC_URL;
+  });
+
+  it("returns the estimated APY from the DeFindex SDK", async () => {
+    const result = await DefindexService.estimateApy();
+
+    expect(result.apy).toBe(5.5);
+    expect(result.contractId).toBe(VAULT_CONTRACT_ID);
+    expect(result.rpcUrl).toBe("https://fake-rpc.example.com");
+    expect(mockGetVaultAPY).toHaveBeenCalledWith(VAULT_CONTRACT_ID, "testnet");
+  });
+
+  it("wraps SDK failures as upstream errors", async () => {
+    mockGetVaultAPY.mockRejectedValue(new Error("apy unavailable"));
+
+    await expect(DefindexService.estimateApy()).rejects.toThrow(
+      /Failed to estimate APY/,
+    );
+  });
+});
+
+describe("DefindexService.buildDepositInvocation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DEFINDEX_VAULT_CONTRACT_ID = VAULT_CONTRACT_ID;
+    process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
+    mockDepositToVault.mockResolvedValue({
+      xdr: "AAAA...deposit",
+      functionName: "deposit",
+      params: [],
+      simulationResponse: {},
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    delete process.env.SOROBAN_RPC_URL;
+  });
+
+  it("builds a deposit invocation via the DeFindex SDK", async () => {
+    const result = await DefindexService.buildDepositInvocation(USER_ADDRESS, [
+      "100000000",
+    ]);
+
+    expect(result.unsignedXdr).toBe("AAAA...deposit");
+    expect(result.functionName).toBe("deposit");
+    expect(result.contractId).toBe(VAULT_CONTRACT_ID);
+    expect(mockDepositToVault).toHaveBeenCalledWith(
+      VAULT_CONTRACT_ID,
+      {
+        caller: USER_ADDRESS,
+        amounts: [100000000],
+        invest: true,
+        slippageBps: undefined,
+      },
+      "testnet",
+    );
+  });
+
+  it("throws when the SDK returns no XDR", async () => {
+    mockDepositToVault.mockResolvedValue({
+      xdr: null,
+      functionName: "deposit",
+      params: [],
+      simulationResponse: {},
+    });
+
+    await expect(
+      DefindexService.buildDepositInvocation(USER_ADDRESS, ["100"]),
+    ).rejects.toThrow(/no transaction XDR/);
+  });
+
+  it("throws for invalid user addresses", async () => {
+    await expect(
+      DefindexService.buildDepositInvocation("not-a-stellar-address", ["100"]),
+    ).rejects.toThrow(/Invalid user address/);
+  });
+
+  it("throws for invalid amounts", async () => {
+    await expect(
+      DefindexService.buildDepositInvocation(USER_ADDRESS, ["0"]),
+    ).rejects.toThrow(/Invalid deposit amount/);
+  });
+});
+
+describe("DefindexService.buildWithdrawInvocation", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.DEFINDEX_VAULT_CONTRACT_ID = VAULT_CONTRACT_ID;
+    process.env.SOROBAN_RPC_URL = "https://fake-rpc.example.com";
+    delete process.env.STELLAR_NETWORK_PASSPHRASE;
+    mockGetHealth.mockResolvedValue({ status: "healthy" });
+    mockWithdrawFromVault.mockResolvedValue({
+      xdr: "AAAA...withdraw",
+      functionName: "withdraw",
+      params: [],
+      simulationResponse: {},
+    });
+  });
+
+  afterEach(() => {
+    delete process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    delete process.env.SOROBAN_RPC_URL;
+  });
+
+  it("builds a withdraw invocation via the DeFindex SDK", async () => {
+    const result = await DefindexService.buildWithdrawInvocation(
+      USER_ADDRESS,
+      ["50000000"],
+      { slippageBps: 100 },
+    );
+
+    expect(result.unsignedXdr).toBe("AAAA...withdraw");
+    expect(result.functionName).toBe("withdraw");
+    expect(mockWithdrawFromVault).toHaveBeenCalledWith(
+      VAULT_CONTRACT_ID,
+      {
+        caller: USER_ADDRESS,
+        amounts: [50000000],
+        slippageBps: 100,
+      },
+      "testnet",
+    );
+  });
+
+  it("wraps SDK failures as upstream errors", async () => {
+    mockWithdrawFromVault.mockRejectedValue(new Error("vault paused"));
+
+    await expect(
+      DefindexService.buildWithdrawInvocation(USER_ADDRESS, ["100"]),
+    ).rejects.toThrow(/Failed to build DeFindex withdraw invocation/);
+  });
+});
+

--- a/backend/package.json
+++ b/backend/package.json
@@ -14,6 +14,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-s3": "^3.1094.0",
+    "@defindex/sdk": "^0.3.0",
     "@libsql/client": "^0.17.0",
     "@prisma/client": "^7.5.0",
     "@stellar/stellar-sdk": "^14.4.3",

--- a/backend/src/lib/services/defindex_service.ts
+++ b/backend/src/lib/services/defindex_service.ts
@@ -34,6 +34,32 @@ import {
   xdr,
 } from "@stellar/stellar-sdk";
 
+/** Configured DeFindex SDK instance plus the Soroban RPC client it talks to. */
+export interface DefindexClient {
+  sdk: DefindexSDK;
+  server: rpc.Server;
+  rpcUrl: string;
+  networkPassphrase: string;
+  network: SupportedNetworks;
+}
+
+/** Estimated vault yield returned by the DeFindex SDK. */
+export interface VaultApyEstimate {
+  apy: number;
+  contractId: string;
+  networkPassphrase: string;
+  rpcUrl: string;
+}
+
+/** Unsigned vault invocation produced by the DeFindex SDK. */
+export interface VaultInvocation {
+  unsignedXdr: string;
+  functionName: string;
+  contractId: string;
+  networkPassphrase: string;
+  rpcUrl: string;
+}
+
 /** Details about the yield / APY estimate for a vault position. */
 export interface APYInfo {
   /**
@@ -261,6 +287,131 @@ class DefindexCache {
 
 const defindexCacheSingleton = new DefindexCache();
 
+function requireUserAddress(userAddress: string): void {
+  if (!StrKey.isValidEd25519PublicKey(userAddress)) {
+    throw new DefindexServiceError(
+      `Invalid user address "${userAddress}": expected a valid Stellar G... public key`,
+      "validation",
+    );
+  }
+}
+
+function requireVaultContractId(): string {
+  const contractId = process.env.DEFINDEX_VAULT_CONTRACT_ID;
+  if (!contractId || !StrKey.isValidContract(contractId)) {
+    throw new DefindexServiceError(
+      "DEFINDEX_VAULT_CONTRACT_ID is not configured: expected a valid Stellar C... contract address",
+      "configuration",
+    );
+  }
+  return contractId;
+}
+
+function parsePositiveAmounts(
+  amounts: string[],
+  kind: "deposit" | "withdrawal",
+): number[] {
+  if (!Array.isArray(amounts) || amounts.length === 0) {
+    throw new DefindexServiceError(
+      `Invalid ${kind} amounts: expected a non-empty array of positive integers in smallest units`,
+      "validation",
+    );
+  }
+  return amounts.map((amount) => {
+    let amountN: bigint;
+    try {
+      amountN = BigInt(amount);
+    } catch {
+      throw new DefindexServiceError(
+        `Invalid ${kind} amount "${amount}": must be a positive integer in smallest units`,
+        "validation",
+      );
+    }
+    if (amountN <= 0n) {
+      throw new DefindexServiceError(
+        `Invalid ${kind} amount "${amount}": must be greater than zero`,
+        "validation",
+      );
+    }
+    const asNumber = Number(amountN);
+    if (!Number.isSafeInteger(asNumber)) {
+      throw new DefindexServiceError(
+        `Invalid ${kind} amount "${amount}": exceeds JavaScript safe integer range required by the DeFindex SDK`,
+        "validation",
+      );
+    }
+    return asNumber;
+  });
+}
+
+function toVaultInvocation(
+  response: VaultTransactionResponse,
+  fallbackFunctionName: string,
+  contractId: string,
+  client: DefindexClient,
+): VaultInvocation {
+  if (!response.xdr) {
+    throw new DefindexServiceError(
+      `DeFindex SDK returned no transaction XDR for ${fallbackFunctionName} on vault ${contractId}`,
+      "upstream",
+    );
+  }
+  return {
+    unsignedXdr: response.xdr,
+    functionName: response.functionName || fallbackFunctionName,
+    contractId,
+    networkPassphrase: client.networkPassphrase,
+    rpcUrl: client.rpcUrl,
+  };
+}
+
+function wrapSdkError(prefix: string, error: unknown): DefindexServiceError {
+  if (error instanceof DefindexServiceError) {
+    return error;
+  }
+  const err = error instanceof Error ? error : new Error(String(error));
+  return new DefindexServiceError(`${prefix}: ${err.message}`, "upstream", err);
+}
+
+async function queryVault(
+  server: rpc.Server,
+  contractId: string,
+  method: string,
+  args: xdr.ScVal[],
+  source: string,
+  networkPassphrase: string,
+): Promise<xdr.ScVal> {
+  const contract = new Contract(contractId);
+  const sourceAccount = new Account(source, "0");
+  const tx = new TransactionBuilder(sourceAccount, {
+    fee: "100",
+    networkPassphrase,
+  })
+    .addOperation(contract.call(method, ...args))
+    .setTimeout(30)
+    .build();
+
+  const simulation = await server.simulateTransaction(tx);
+  const simulationError =
+    simulation && "error" in simulation
+      ? (simulation as rpc.Api.SimulateTransactionErrorResponse).error
+      : undefined;
+  if (
+    !simulation ||
+    "error" in simulation ||
+    !simulation.result ||
+    simulation.result.retval === undefined
+  ) {
+    throw new DefindexServiceError(
+      `Failed to query ${method} on vault ${contractId}${
+        simulationError ? `: ${simulationError}` : ""
+      }`,
+      "upstream",
+    );
+  }
+  return simulation.result.retval;
+}
+
 export class DefindexService {
   /**
    * Queries a user's DeFindex vault position on Soroban, including user share balance,
@@ -313,7 +464,7 @@ export class DefindexService {
 
           const userBalanceRaw = BigInt(
             scValToNative(
-              await DefindexService.queryVault(
+              await queryVault(
                 server,
                 contractId,
                 "balance_of",
@@ -326,7 +477,7 @@ export class DefindexService {
 
           const totalSupplyRaw = BigInt(
             scValToNative(
-              await DefindexService.queryVault(
+              await queryVault(
                 server,
                 contractId,
                 "total_supply",
@@ -338,7 +489,7 @@ export class DefindexService {
           );
 
           const managedFunds = scValToNative(
-            await DefindexService.queryVault(
+            await queryVault(
               server,
               contractId,
               "fetch_total_managed_funds",
@@ -480,6 +631,212 @@ export class DefindexService {
   static clearCache(): void {
     defindexCacheSingleton.clear();
   }
+
+  /**
+   * Resolves RPC URL, network passphrase, and DeFindex network from env.
+   */
+  static resolveConfig(): {
+    rpcUrl: string;
+    networkPassphrase: string;
+    network: SupportedNetworks;
+  } {
+    const rpcUrl =
+      process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
+    const networkPassphrase =
+      process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
+    const network =
+      networkPassphrase === Networks.PUBLIC
+        ? SupportedNetworks.MAINNET
+        : SupportedNetworks.TESTNET;
+    return { rpcUrl, networkPassphrase, network };
+  }
+
+  /**
+   * Instantiates the DeFindex server SDK and a Soroban RPC client, configured
+   * with the RPC URL and network passphrase. Constructor failures (invalid
+   * RPC URL, SDK init errors) are wrapped as `DefindexServiceError`.
+   */
+  static createClient(): DefindexClient {
+    const { rpcUrl, networkPassphrase, network } = DefindexService.resolveConfig();
+    try {
+      const server = new rpc.Server(rpcUrl);
+      const sdk = new DefindexSDK({
+        apiKey: process.env.DEFINDEX_API_KEY,
+        baseUrl: process.env.DEFINDEX_API_URL,
+        timeout: 30_000,
+        defaultNetwork: network,
+      });
+      return { sdk, server, rpcUrl, networkPassphrase, network };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw new DefindexServiceError(
+        `Failed to initialize DeFindex SDK for RPC ${rpcUrl}: ${err.message}`,
+        "upstream",
+        err,
+      );
+    }
+  }
+
+  /**
+   * Creates the SDK client and verifies Soroban RPC connectivity. RPC
+   * transport failures are wrapped as `kind: "upstream"` errors.
+   */
+  static async initialize(): Promise<DefindexClient> {
+    const client = DefindexService.createClient();
+    try {
+      await client.server.getHealth();
+    } catch (error) {
+      if (error instanceof DefindexServiceError) {
+        throw error;
+      }
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw new DefindexServiceError(
+        `Failed to connect to Soroban RPC at ${client.rpcUrl}: ${err.message}`,
+        "upstream",
+        err,
+      );
+    }
+    return client;
+  }
+
+  /**
+   * Queries vault metadata, managed funds, fees, and reported APY via the
+   * DeFindex server SDK.
+   */
+  static async queryVaultInfo(
+    vaultAddress?: string,
+  ): Promise<VaultInfoResponse> {
+    const contractId = vaultAddress || requireVaultContractId();
+    const client = await DefindexService.initialize();
+    try {
+      return await client.sdk.getVaultInfo(contractId, client.network);
+    } catch (error) {
+      throw wrapSdkError(
+        `Failed to query vault info for ${contractId}`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Estimates the vault's current yield rate (APY) via the DeFindex SDK.
+   */
+  static async estimateApy(vaultAddress?: string): Promise<VaultApyEstimate> {
+    const contractId = vaultAddress || requireVaultContractId();
+    const client = await DefindexService.initialize();
+    try {
+      const apy: VaultApyResponse = await client.sdk.getVaultAPY(
+        contractId,
+        client.network,
+      );
+      return {
+        apy: apy.apy,
+        contractId,
+        networkPassphrase: client.networkPassphrase,
+        rpcUrl: client.rpcUrl,
+      };
+    } catch (error) {
+      throw wrapSdkError(
+        `Failed to estimate APY for vault ${contractId}`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Builds an unsigned deposit invocation through the DeFindex SDK.
+   *
+   * @param userAddress Stellar G... address that signs the deposit.
+   * @param amounts Per-asset deposit amounts in smallest units.
+   */
+  static async buildDepositInvocation(
+    userAddress: string,
+    amounts: string[],
+    options: { invest?: boolean; slippageBps?: number; vaultAddress?: string } = {},
+  ): Promise<VaultInvocation> {
+    requireUserAddress(userAddress);
+    const parsedAmounts = parsePositiveAmounts(
+      amounts,
+      "deposit",
+    );
+    const contractId =
+      options.vaultAddress || requireVaultContractId();
+    const client = await DefindexService.initialize();
+
+    const depositData: DefindexSdkDepositParams = {
+      caller: userAddress,
+      amounts: parsedAmounts,
+      invest: options.invest ?? true,
+      slippageBps: options.slippageBps,
+    };
+
+    try {
+      const response: VaultTransactionResponse = await client.sdk.depositToVault(
+        contractId,
+        depositData,
+        client.network,
+      );
+      return toVaultInvocation(
+        response,
+        "deposit",
+        contractId,
+        client,
+      );
+    } catch (error) {
+      throw wrapSdkError(
+        `Failed to build DeFindex deposit invocation for ${userAddress}`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Builds an unsigned withdraw invocation through the DeFindex SDK.
+   *
+   * @param userAddress Stellar G... address that owns the vault shares.
+   * @param amounts Per-asset withdrawal amounts in smallest units.
+   */
+  static async buildWithdrawInvocation(
+    userAddress: string,
+    amounts: string[],
+    options: { slippageBps?: number; vaultAddress?: string } = {},
+  ): Promise<VaultInvocation> {
+    requireUserAddress(userAddress);
+    const parsedAmounts = parsePositiveAmounts(
+      amounts,
+      "withdrawal",
+    );
+    const contractId =
+      options.vaultAddress || requireVaultContractId();
+    const client = await DefindexService.initialize();
+
+    const withdrawData: DefindexSdkWithdrawParams = {
+      caller: userAddress,
+      amounts: parsedAmounts,
+      slippageBps: options.slippageBps,
+    };
+
+    try {
+      const response: VaultTransactionResponse =
+        await client.sdk.withdrawFromVault(
+          contractId,
+          withdrawData,
+          client.network,
+        );
+      return toVaultInvocation(
+        response,
+        "withdraw",
+        contractId,
+        client,
+      );
+    } catch (error) {
+      throw wrapSdkError(
+        `Failed to build DeFindex withdraw invocation for ${userAddress}`,
+        error,
+      );
+    }
+  }
+
   /**
    * Calculates the Soroban parameters required to withdraw `amount` of USDC
    * from the DeFindex vault on behalf of `userAddress` and returns an
@@ -504,7 +861,7 @@ export class DefindexService {
     userAddress: string,
     amount: string,
   ): Promise<WithdrawalParams> {
-    DefindexService.requireUserAddress(userAddress);
+    requireUserAddress(userAddress);
 
     let amountN: bigint;
     try {
@@ -522,7 +879,7 @@ export class DefindexService {
       );
     }
 
-    const contractId = DefindexService.requireVaultContractId();
+    const contractId = requireVaultContractId();
     const { server, rpcUrl, networkPassphrase } = DefindexService.createClient();
 
     try {
@@ -531,7 +888,7 @@ export class DefindexService {
 
       const userBalance = BigInt(
         scValToNative(
-          await DefindexService.queryVault(
+          await queryVault(
             server,
             contractId,
             "balance_of",
@@ -544,7 +901,7 @@ export class DefindexService {
 
       const totalSupply = BigInt(
         scValToNative(
-          await DefindexService.queryVault(
+          await queryVault(
             server,
             contractId,
             "total_supply",
@@ -556,7 +913,7 @@ export class DefindexService {
       );
 
       const managedFunds = scValToNative(
-        await DefindexService.queryVault(
+        await queryVault(
           server,
           contractId,
           "fetch_total_managed_funds",
@@ -707,54 +1064,11 @@ export class DefindexService {
     }
   }
 
-  /**
-   * Invokes a read-only vault contract method through Soroban RPC and returns
-   * the decoded return value as an `xdr.ScVal`.
-   */
-  private static async queryVault(
-    server: rpc.Server,
-    contractId: string,
-    method: string,
-    args: xdr.ScVal[],
-    source: string,
-    networkPassphrase: string,
-  ): Promise<xdr.ScVal> {
-    const contract = new Contract(contractId);
-    const sourceAccount = new Account(source, "0");
-    const tx = new TransactionBuilder(sourceAccount, {
-      fee: "100",
-      networkPassphrase,
-    })
-      .addOperation(contract.call(method, ...args))
-      .setTimeout(30)
-      .build();
-
-    const simulation = await server.simulateTransaction(tx);
-    const simulationError =
-      simulation && "error" in simulation
-        ? (simulation as rpc.Api.SimulateTransactionErrorResponse).error
-        : undefined;
-    if (
-      !simulation ||
-      "error" in simulation ||
-      !simulation.result ||
-      simulation.result.retval === undefined
-    ) {
-      throw new DefindexServiceError(
-        `Failed to query ${method} on vault ${contractId}${
-          simulationError ? `: ${simulationError}` : ""
-        }`,
-        "upstream",
-      );
-    }
-    return simulation.result.retval;
-  }
-
   static async calculateDepositParams(
     userAddress: string,
     amount: string,
   ): Promise<DepositParams> {
-    DefindexService.requireUserAddress(userAddress);
+    requireUserAddress(userAddress);
 
     let amountN: bigint;
     try {
@@ -772,13 +1086,13 @@ export class DefindexService {
       );
     }
 
-    const contractId = DefindexService.requireVaultContractId();
+    const contractId = requireVaultContractId();
     const { server, rpcUrl, networkPassphrase } = DefindexService.createClient();
 
     try {
       const totalSupply = BigInt(
         scValToNative(
-          await DefindexService.queryVault(
+          await queryVault(
             server,
             contractId,
             "total_supply",
@@ -790,7 +1104,7 @@ export class DefindexService {
       );
 
       const managedFunds = scValToNative(
-        await DefindexService.queryVault(
+        await queryVault(
           server,
           contractId,
           "fetch_total_managed_funds",
@@ -847,7 +1161,7 @@ export class DefindexService {
 
       const userBalance = BigInt(
         scValToNative(
-          await DefindexService.queryVault(
+          await queryVault(
             server,
             contractId,
             "balance_of",

--- a/backend/src/lib/services/defindex_service.ts
+++ b/backend/src/lib/services/defindex_service.ts
@@ -1,13 +1,25 @@
 // DeFindex Service
-// Interfaces with a DeFindex vault contract on Stellar/Soroban to calculate
-// withdrawal parameters (shares to burn, expected USDC assets, and the
-// necessary Soroban contract footprint) and to build the unsigned
-// withdrawal transaction XDR.
+// Instantiates the official DeFindex server SDK and a Soroban RPC client to
+// query vault parameters, estimate yield rates (APY), and build unsigned
+// smart-contract invocations. Deposit/withdrawal parameter calculation still
+// queries vault state over RPC so the returned XDR carries a simulated
+// contract footprint.
 //
 // Environment variables:
 // - DEFINDEX_VAULT_CONTRACT_ID: address (C...) of the DeFindex vault contract
+// - DEFINDEX_API_KEY: optional API key for the DeFindex server SDK
+// - DEFINDEX_API_URL: optional DeFindex API base URL
 // - SOROBAN_RPC_URL: Soroban RPC endpoint (defaults to Soroban testnet)
 // - STELLAR_NETWORK_PASSPHRASE: network passphrase (defaults to testnet)
+import {
+  DefindexSDK,
+  SupportedNetworks,
+  type DepositParams as DefindexSdkDepositParams,
+  type VaultApyResponse,
+  type VaultInfoResponse,
+  type VaultTransactionResponse,
+  type WithdrawParams as DefindexSdkWithdrawParams,
+} from "@defindex/sdk";
 import {
   Account,
   Address,
@@ -21,6 +33,32 @@ import {
   scValToNative,
   xdr,
 } from "@stellar/stellar-sdk";
+
+/** Configured DeFindex SDK instance plus the Soroban RPC client it talks to. */
+export interface DefindexClient {
+  sdk: DefindexSDK;
+  server: rpc.Server;
+  rpcUrl: string;
+  networkPassphrase: string;
+  network: SupportedNetworks;
+}
+
+/** Estimated vault yield returned by the DeFindex SDK. */
+export interface VaultApyEstimate {
+  apy: number;
+  contractId: string;
+  networkPassphrase: string;
+  rpcUrl: string;
+}
+
+/** Unsigned vault invocation produced by the DeFindex SDK. */
+export interface VaultInvocation {
+  unsignedXdr: string;
+  functionName: string;
+  contractId: string;
+  networkPassphrase: string;
+  rpcUrl: string;
+}
 
 /** Results of a DeFindex deposit parameter calculation. */
 export interface DepositParams {
@@ -95,6 +133,297 @@ export class DefindexServiceError extends Error {
 
 export class DefindexService {
   /**
+   * Resolves RPC URL, network passphrase, and DeFindex network from env.
+   */
+  static resolveConfig(): {
+    rpcUrl: string;
+    networkPassphrase: string;
+    network: SupportedNetworks;
+  } {
+    const rpcUrl =
+      process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
+    const networkPassphrase =
+      process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
+    const network =
+      networkPassphrase === Networks.PUBLIC
+        ? SupportedNetworks.MAINNET
+        : SupportedNetworks.TESTNET;
+    return { rpcUrl, networkPassphrase, network };
+  }
+
+  /**
+   * Instantiates the DeFindex server SDK and a Soroban RPC client, configured
+   * with the RPC URL and network passphrase. Constructor failures (invalid
+   * RPC URL, SDK init errors) are wrapped as `DefindexServiceError`.
+   */
+  static createClient(): DefindexClient {
+    const { rpcUrl, networkPassphrase, network } = DefindexService.resolveConfig();
+    try {
+      const server = new rpc.Server(rpcUrl);
+      const sdk = new DefindexSDK({
+        apiKey: process.env.DEFINDEX_API_KEY,
+        baseUrl: process.env.DEFINDEX_API_URL,
+        timeout: 30_000,
+        defaultNetwork: network,
+      });
+      return { sdk, server, rpcUrl, networkPassphrase, network };
+    } catch (error) {
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw new DefindexServiceError(
+        `Failed to initialize DeFindex SDK for RPC ${rpcUrl}: ${err.message}`,
+        "upstream",
+        err,
+      );
+    }
+  }
+
+  /**
+   * Creates the SDK client and verifies Soroban RPC connectivity. RPC
+   * transport failures are wrapped as `kind: "upstream"` errors.
+   */
+  static async initialize(): Promise<DefindexClient> {
+    const client = DefindexService.createClient();
+    try {
+      await client.server.getHealth();
+    } catch (error) {
+      if (error instanceof DefindexServiceError) {
+        throw error;
+      }
+      const err = error instanceof Error ? error : new Error(String(error));
+      throw new DefindexServiceError(
+        `Failed to connect to Soroban RPC at ${client.rpcUrl}: ${err.message}`,
+        "upstream",
+        err,
+      );
+    }
+    return client;
+  }
+
+  /**
+   * Queries vault metadata, managed funds, fees, and reported APY via the
+   * DeFindex server SDK.
+   */
+  static async queryVaultInfo(
+    vaultAddress?: string,
+  ): Promise<VaultInfoResponse> {
+    const contractId = vaultAddress || DefindexService.requireVaultContractId();
+    const client = await DefindexService.initialize();
+    try {
+      return await client.sdk.getVaultInfo(contractId, client.network);
+    } catch (error) {
+      throw DefindexService.wrapSdkError(
+        `Failed to query vault info for ${contractId}`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Estimates the vault's current yield rate (APY) via the DeFindex SDK.
+   */
+  static async estimateApy(vaultAddress?: string): Promise<VaultApyEstimate> {
+    const contractId = vaultAddress || DefindexService.requireVaultContractId();
+    const client = await DefindexService.initialize();
+    try {
+      const apy: VaultApyResponse = await client.sdk.getVaultAPY(
+        contractId,
+        client.network,
+      );
+      return {
+        apy: apy.apy,
+        contractId,
+        networkPassphrase: client.networkPassphrase,
+        rpcUrl: client.rpcUrl,
+      };
+    } catch (error) {
+      throw DefindexService.wrapSdkError(
+        `Failed to estimate APY for vault ${contractId}`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Builds an unsigned deposit invocation through the DeFindex SDK.
+   *
+   * @param userAddress Stellar G... address that signs the deposit.
+   * @param amounts Per-asset deposit amounts in smallest units.
+   */
+  static async buildDepositInvocation(
+    userAddress: string,
+    amounts: string[],
+    options: { invest?: boolean; slippageBps?: number; vaultAddress?: string } = {},
+  ): Promise<VaultInvocation> {
+    DefindexService.requireUserAddress(userAddress);
+    const parsedAmounts = DefindexService.parsePositiveAmounts(
+      amounts,
+      "deposit",
+    );
+    const contractId =
+      options.vaultAddress || DefindexService.requireVaultContractId();
+    const client = await DefindexService.initialize();
+
+    const depositData: DefindexSdkDepositParams = {
+      caller: userAddress,
+      amounts: parsedAmounts,
+      invest: options.invest ?? true,
+      slippageBps: options.slippageBps,
+    };
+
+    try {
+      const response: VaultTransactionResponse = await client.sdk.depositToVault(
+        contractId,
+        depositData,
+        client.network,
+      );
+      return DefindexService.toVaultInvocation(
+        response,
+        "deposit",
+        contractId,
+        client,
+      );
+    } catch (error) {
+      throw DefindexService.wrapSdkError(
+        `Failed to build DeFindex deposit invocation for ${userAddress}`,
+        error,
+      );
+    }
+  }
+
+  /**
+   * Builds an unsigned withdraw invocation through the DeFindex SDK.
+   *
+   * @param userAddress Stellar G... address that owns the vault shares.
+   * @param amounts Per-asset withdrawal amounts in smallest units.
+   */
+  static async buildWithdrawInvocation(
+    userAddress: string,
+    amounts: string[],
+    options: { slippageBps?: number; vaultAddress?: string } = {},
+  ): Promise<VaultInvocation> {
+    DefindexService.requireUserAddress(userAddress);
+    const parsedAmounts = DefindexService.parsePositiveAmounts(
+      amounts,
+      "withdrawal",
+    );
+    const contractId =
+      options.vaultAddress || DefindexService.requireVaultContractId();
+    const client = await DefindexService.initialize();
+
+    const withdrawData: DefindexSdkWithdrawParams = {
+      caller: userAddress,
+      amounts: parsedAmounts,
+      slippageBps: options.slippageBps,
+    };
+
+    try {
+      const response: VaultTransactionResponse =
+        await client.sdk.withdrawFromVault(
+          contractId,
+          withdrawData,
+          client.network,
+        );
+      return DefindexService.toVaultInvocation(
+        response,
+        "withdraw",
+        contractId,
+        client,
+      );
+    } catch (error) {
+      throw DefindexService.wrapSdkError(
+        `Failed to build DeFindex withdraw invocation for ${userAddress}`,
+        error,
+      );
+    }
+  }
+
+  private static requireUserAddress(userAddress: string): void {
+    if (!StrKey.isValidEd25519PublicKey(userAddress)) {
+      throw new DefindexServiceError(
+        `Invalid user address "${userAddress}": expected a valid Stellar G... public key`,
+        "validation",
+      );
+    }
+  }
+
+  private static requireVaultContractId(): string {
+    const contractId = process.env.DEFINDEX_VAULT_CONTRACT_ID;
+    if (!contractId || !StrKey.isValidContract(contractId)) {
+      throw new DefindexServiceError(
+        "DEFINDEX_VAULT_CONTRACT_ID is not configured: expected a valid Stellar C... contract address",
+        "configuration",
+      );
+    }
+    return contractId;
+  }
+
+  private static parsePositiveAmounts(
+    amounts: string[],
+    kind: "deposit" | "withdrawal",
+  ): number[] {
+    if (!Array.isArray(amounts) || amounts.length === 0) {
+      throw new DefindexServiceError(
+        `Invalid ${kind} amounts: expected a non-empty array of positive integers in smallest units`,
+        "validation",
+      );
+    }
+    return amounts.map((amount) => {
+      let amountN: bigint;
+      try {
+        amountN = BigInt(amount);
+      } catch {
+        throw new DefindexServiceError(
+          `Invalid ${kind} amount "${amount}": must be a positive integer in smallest units`,
+          "validation",
+        );
+      }
+      if (amountN <= 0n) {
+        throw new DefindexServiceError(
+          `Invalid ${kind} amount "${amount}": must be greater than zero`,
+          "validation",
+        );
+      }
+      const asNumber = Number(amountN);
+      if (!Number.isSafeInteger(asNumber)) {
+        throw new DefindexServiceError(
+          `Invalid ${kind} amount "${amount}": exceeds JavaScript safe integer range required by the DeFindex SDK`,
+          "validation",
+        );
+      }
+      return asNumber;
+    });
+  }
+
+  private static toVaultInvocation(
+    response: VaultTransactionResponse,
+    fallbackFunctionName: string,
+    contractId: string,
+    client: DefindexClient,
+  ): VaultInvocation {
+    if (!response.xdr) {
+      throw new DefindexServiceError(
+        `DeFindex SDK returned no transaction XDR for ${fallbackFunctionName} on vault ${contractId}`,
+        "upstream",
+      );
+    }
+    return {
+      unsignedXdr: response.xdr,
+      functionName: response.functionName || fallbackFunctionName,
+      contractId,
+      networkPassphrase: client.networkPassphrase,
+      rpcUrl: client.rpcUrl,
+    };
+  }
+
+  private static wrapSdkError(prefix: string, error: unknown): DefindexServiceError {
+    if (error instanceof DefindexServiceError) {
+      return error;
+    }
+    const err = error instanceof Error ? error : new Error(String(error));
+    return new DefindexServiceError(`${prefix}: ${err.message}`, "upstream", err);
+  }
+
+  /**
    * Calculates the Soroban parameters required to withdraw `amount` of USDC
    * from the DeFindex vault on behalf of `userAddress` and returns an
    * unsigned withdrawal transaction XDR.
@@ -118,19 +447,7 @@ export class DefindexService {
     userAddress: string,
     amount: string,
   ): Promise<WithdrawalParams> {
-    const contractId = process.env.DEFINDEX_VAULT_CONTRACT_ID;
-    const rpcUrl =
-      process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
-    const networkPassphrase =
-      process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
-
-    // ── Input validation ───────────────────────────────────────────────────
-    if (!StrKey.isValidEd25519PublicKey(userAddress)) {
-      throw new DefindexServiceError(
-        `Invalid user address "${userAddress}": expected a valid Stellar G... public key`,
-        "validation",
-      );
-    }
+    DefindexService.requireUserAddress(userAddress);
 
     let amountN: bigint;
     try {
@@ -148,14 +465,8 @@ export class DefindexService {
       );
     }
 
-    if (!contractId || !StrKey.isValidContract(contractId)) {
-      throw new DefindexServiceError(
-        "DEFINDEX_VAULT_CONTRACT_ID is not configured: expected a valid Stellar C... contract address",
-        "configuration",
-      );
-    }
-
-    const server = new rpc.Server(rpcUrl);
+    const contractId = DefindexService.requireVaultContractId();
+    const { server, rpcUrl, networkPassphrase } = DefindexService.createClient();
 
     try {
       // ── Query vault state via Soroban RPC ────────────────────────────────
@@ -386,18 +697,7 @@ export class DefindexService {
     userAddress: string,
     amount: string,
   ): Promise<DepositParams> {
-    const contractId = process.env.DEFINDEX_VAULT_CONTRACT_ID;
-    const rpcUrl =
-      process.env.SOROBAN_RPC_URL || "https://soroban-testnet.stellar.org";
-    const networkPassphrase =
-      process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
-
-    if (!StrKey.isValidEd25519PublicKey(userAddress)) {
-      throw new DefindexServiceError(
-        `Invalid user address "${userAddress}": expected a valid Stellar G... public key`,
-        "validation",
-      );
-    }
+    DefindexService.requireUserAddress(userAddress);
 
     let amountN: bigint;
     try {
@@ -415,14 +715,8 @@ export class DefindexService {
       );
     }
 
-    if (!contractId || !StrKey.isValidContract(contractId)) {
-      throw new DefindexServiceError(
-        "DEFINDEX_VAULT_CONTRACT_ID is not configured: expected a valid Stellar C... contract address",
-        "configuration",
-      );
-    }
-
-    const server = new rpc.Server(rpcUrl);
+    const contractId = DefindexService.requireVaultContractId();
+    const { server, rpcUrl, networkPassphrase } = DefindexService.createClient();
 
     try {
       const totalSupply = BigInt(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -24,6 +24,9 @@ importers:
       '@aws-sdk/client-s3':
         specifier: ^3.1094.0
         version: 3.1094.0
+      '@defindex/sdk':
+        specifier: ^0.3.0
+        version: 0.3.0
       '@libsql/client':
         specifier: ^0.17.0
         version: 0.17.4
@@ -484,6 +487,10 @@ packages:
   '@cspotcode/source-map-support@0.8.1':
     resolution: {integrity: sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==}
     engines: {node: '>=12'}
+
+  '@defindex/sdk@0.3.0':
+    resolution: {integrity: sha512-44l8wHOvKiiS4oWqKJkC9SI7j/CSvphZLUA4DfjNauH2qIWLcfxovN6nFfIToSUrWw863iR2xmJn48jxG1CwDw==}
+    engines: {node: '>=16.0.0'}
 
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
@@ -1040,105 +1047,89 @@ packages:
     resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.4':
     resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.4':
     resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-riscv64@1.2.4':
     resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.4':
     resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.4':
     resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
     resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.4':
     resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.34.5':
     resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.5':
     resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.5':
     resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-riscv64@0.34.5':
     resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.5':
     resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.5':
     resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.34.5':
     resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.5':
     resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.34.5':
     resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
@@ -1431,28 +1422,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-arm64-musl@16.1.2':
     resolution: {integrity: sha512-Sn6LxPIZcADe5AnqqMCfwBv6vRtDikhtrjwhu+19WM6jHZe31JDRcGuPZAlJrDk6aEbNBPUUAKmySJELkBOesg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-linux-x64-gnu@16.1.2':
     resolution: {integrity: sha512-nwzesEQBfQIOOnQ7JArzB08w9qwvBQ7nC1i8gb0tiEFH94apzQM3IRpY19MlE8RBHxc9ArG26t1DEg2aaLaqVQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@next/swc-linux-x64-musl@16.1.2':
     resolution: {integrity: sha512-s60bLf16BDoICQHeKEm0lDgUNMsL1UpQCkRNZk08ZNnRpK0QUV+6TvVHuBcIA7oItzU0m7kVmXe8QjXngYxJVA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@next/swc-win32-arm64-msvc@16.1.2':
     resolution: {integrity: sha512-Sq8k4SZd8Y8EokKdz304TvMO9HoiwGzo0CTacaiN1bBtbJSQ1BIwKzNFeFdxOe93SHn1YGnKXG6Mq3N+tVooyQ==}
@@ -1634,28 +1621,24 @@ packages:
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.3.3':
     resolution: {integrity: sha512-Md44bD6veX/PC5iyF8cDVnw4HBIANZepRZZ7a8DQOvkfo5WUBwcp6iAuCUz23u+4SUkhJlD3eL7hNdW8ezd/kA==}
     engines: {node: '>= 20'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.3.3':
     resolution: {integrity: sha512-tx7us1muwOKAKWao2v/GaafFeQboE6aj88vC6ziN2NCGcRm8gWUhwjzg+YdVB1e4boAtdtma4L43onunI6NS4w==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.3.3':
     resolution: {integrity: sha512-SJxX60smvHgasZoBy11dX6YRjXJFovwWBoedhbQPOBzgFWBHGB+TVPWB9BxzR7TTxU8FQZAI2AyiNCMzFm8Img==}
     engines: {node: '>= 20'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.3.3':
     resolution: {integrity: sha512-jx1+rPhY/5Ympkktd656HBWEBLxP7dH06losBLjjf5vgCODXvi9KhtftWcMIwTFIDqBr7cRnQkdLnAG+IOlGvQ==}
@@ -1944,61 +1927,51 @@ packages:
     resolution: {integrity: sha512-zJc0H99FEPoFfSrNpa91HYfxzfAJCr502oxNK1cfdC9hlaFI43RT+JFCann9JUgZmLzzntChHyn13Sgn9ljHNg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.12.2':
     resolution: {integrity: sha512-KQ3Lki6l+Pz1k/eBipN41ES+YUK30beLGb9YqcB1O542cyLCNE6GaxrfcY3T6EezmGGk84wb5XyO9loTM9tkcA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-loong64-gnu@1.12.2':
     resolution: {integrity: sha512-3SJGEh1DborhG6pyxvhPzCT4bbSIVihsvgJc13P1bHG7KLdNDaF9T3gsTwFc7Jw/5Y5/iWOjkEx7Zy0NvCGX3Q==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-loong64-musl@1.12.2':
     resolution: {integrity: sha512-jiuG/Obbel7uw1PwHNFfrkiKhLAF6mnyZ6aWlOAVN9WqKm8v0OFGnciJIHu8+CMvXLQ8AD51LPzAoUfT21D5Ew==}
     cpu: [loong64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.12.2':
     resolution: {integrity: sha512-q7xRvVpmcfeL+LlZg8Pbbo6QaTZwDU5BaGZbwfhkEsXJn3Was8xYfE0RBH266xZt0rM6B7i8xAYIvjthuUIWHg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.12.2':
     resolution: {integrity: sha512-0CVdx6lcnT3Q9inOH8tsMIOJ6ImndllMjqJHg8RLVdB7Vq4SfkEXl9mCSsVNuNA4MCYycRicCUxPCabVHJRr6A==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.12.2':
     resolution: {integrity: sha512-iOwlRo9vnp6R6ohHQS11n0NnfdXx/omhkocmIfaPRpQhKZ+3BDMkkdRVh53qjkFkpPddf+FETA28NwGN7l5l+w==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.12.2':
     resolution: {integrity: sha512-HYJtLfXq94q8iZNFT1lknx258wlkkWhZeUXJRqzKBBUJ00CvZ+N33zgbCqimLjsyw5Va6uUxhVa12mI+kaveEw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.12.2':
     resolution: {integrity: sha512-mPsUhunKKDih5O96Y6enDQyHc1SqBPlY1E/SfMWDM3EdJ95Z9CArPeCVwCCqbP45ljvivdEk8Fxn+SIb1rDAJQ==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.12.2':
     resolution: {integrity: sha512-azrt6+5ydLd8Vt210AAFis/lZevSfPw93EJRIJG+xPu4WCJ8K0kppCTpMyLPcKT7H15M4Jnt2tMp5bOvCkRC6A==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-openharmony-arm64@1.12.2':
     resolution: {integrity: sha512-YZ9hP4O0X9PQb8eO980qmLNGH4zT3I9+SZTdt0Pr0YyuGQhYKoOZkV02VzrzyOZJ5xIJ3UFIenKkUkGg8GjgWQ==}
@@ -2881,6 +2854,7 @@ packages:
   eslint@9.39.5:
     resolution: {integrity: sha512-DgZS62aPLXKlnxILS/AYCoRvHaZeXceIzlXPkkGGzJWSow1aEk0lbTlxUSlyjC8jcaKxAdOnTDz+o1JFSBsyjw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+    deprecated: This version is no longer supported. Please see https://eslint.org/version-support for other options.
     hasBin: true
     peerDependencies:
       jiti: '*'
@@ -3806,28 +3780,24 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-win32-arm64-msvc@1.32.0:
     resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
@@ -5406,6 +5376,13 @@ snapshots:
   '@cspotcode/source-map-support@0.8.1':
     dependencies:
       '@jridgewell/trace-mapping': 0.3.9
+
+  '@defindex/sdk@0.3.0':
+    dependencies:
+      axios: 1.18.1
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   '@drizzle-team/brocli@0.10.2': {}
 
@@ -7704,8 +7681,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.1.2
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.1.1(eslint@9.39.5(jiti@2.7.0))
@@ -7727,7 +7704,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -7738,22 +7715,22 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -7764,7 +7741,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.64.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3


### PR DESCRIPTION
## Description
Integrate the official DeFindex server SDK into the Node.js backend so vault parameters, APY, and unsigned Soroban invocations can be queried/built from a single helper service.

## How It Was Done
- Added `@defindex/sdk` to `backend/package.json`.
- Instantiated `DefindexSDK` in `defindex_service.ts` with RPC URL and network passphrase (`SOROBAN_RPC_URL`, `STELLAR_NETWORK_PASSPHRASE`), plus optional `DEFINDEX_API_KEY` / `DEFINDEX_API_URL`.
- Wrapped SDK/RPC initialization in try/catch and pinged Soroban RPC `getHealth()` so connectivity failures surface as `DefindexServiceError` (`kind: "upstream"`).
- Added helpers: `queryVaultInfo`, `estimateApy`, `buildDepositInvocation`, `buildWithdrawInvocation`. Existing deposit/withdraw parameter calculation now goes through the same client.

## Issues Encountered (If Any)
The official SDK is an HTTP API client (apiKey/baseUrl/network), not an RPC constructor. RPC URL and passphrase are applied on our wrapper: passphrase selects `SupportedNetworks`, and `rpc.Server` is created/health-checked for Soroban connectivity.

## Related Issue
Closes #400

## How It Was Tested
- `pnpm --filter zendvo-backend exec drizzle-kit check`
- `pnpm -r --if-present run test` (361 backend + 1 web, all passing)
- `pnpm -r --if-present run build` (backend tsc + Next.js production build)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added DeFi vault integration for viewing vault information, balances, share prices, and APY estimates.
  * Added support for preparing deposit and withdrawal transactions.
  * Added testnet and mainnet network configuration.
  * Improved validation and error handling for vault operations.
  * Added caching for vault balance data.

* **Tests**
  * Expanded coverage for vault balances, share prices, caching, APY estimates, transaction preparation, and error scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->