### PR TITLE
feat(wallet): add sponsored USDC trustline endpoint

### DIFF
--- a/backend/src/api/wallet/trustline.ts
+++ b/backend/src/api/wallet/trustline.ts
@@ -1,5 +1,51 @@
-// Placeholder: API Endpoint to Generate Sponsored USDC `changeTrust` XDR
-// Will call trustline_service to build the sponsored trustline operation.
-export const trustlineEndpoint = async (req: any, res: any) => {
-  res.status(501).json({ message: "Not implemented yet" });
-};
+import { NextRequest, NextResponse } from "next/server";
+import { TrustlineService } from "../../lib/stellar/trustline_service";
+import { getAuthPayload } from "@/lib/auth-session";
+import { createProblemDetails } from "@/lib/api-utils";
+import { db } from "@/lib/db";
+import { users } from "@/lib/db/schema";
+import { eq } from "drizzle-orm";
+
+export async function POST(request: NextRequest) {
+  try {
+    const payload = await getAuthPayload(request);
+    if (!payload) {
+      return createProblemDetails(
+        "about:blank",
+        "Unauthorized",
+        401,
+        "Authentication required",
+      );
+    }
+
+    const { userId } = payload;
+
+    const [user] = await db
+      .select({ stellarAddress: users.stellarAddress })
+      .from(users)
+      .where(eq(users.id, userId));
+
+    if (!user?.stellarAddress) {
+      return createProblemDetails(
+        "about:blank",
+        "Bad Request",
+        400,
+        "No Stellar address registered for this account",
+      );
+    }
+
+    const xdr = await TrustlineService.buildSponsoredUsdcTrustlineXdr(
+      user.stellarAddress,
+    );
+
+    return NextResponse.json({ success: true, xdr }, { status: 200 });
+  } catch (error: any) {
+    console.error("[WALLET_TRUSTLINE_ERROR]", error);
+    return createProblemDetails(
+      "about:blank",
+      "Internal Server Error",
+      500,
+      error?.message || "Failed to build sponsored trustline transaction",
+    );
+  }
+}

--- a/backend/src/lib/stellar/trustline_service.ts
+++ b/backend/src/lib/stellar/trustline_service.ts
@@ -1,8 +1,97 @@
-// Placeholder: Stellar Trustline Service
-// Builds sponsored changeTrust operations for USDC.
+import {
+  Keypair,
+  TransactionBuilder,
+  Networks,
+  Operation,
+  Account,
+  Asset,
+  Horizon,
+} from "@stellar/stellar-sdk";
+
 export class TrustlineService {
-  static buildSponsoredUsdcTrustlineXdr(userAddress: string): string {
-    // TODO: Implement sponsored reserve trustline logic
-    return "base64_unsigned_xdr_placeholder";
+  private static horizonUrl =
+    process.env.STELLAR_HORIZON_URL || "https://horizon-testnet.stellar.org";
+  private static server = new Horizon.Server(TrustlineService.horizonUrl);
+
+  private static sponsorAccount: Account | null = null;
+  private static isFetching = false;
+  private static mutexQueue: Array<() => void> = [];
+
+  private static async lock(): Promise<void> {
+    if (!this.isFetching) {
+      this.isFetching = true;
+      return Promise.resolve();
+    }
+    return new Promise((resolve) => {
+      this.mutexQueue.push(resolve);
+    });
+  }
+
+  private static unlock() {
+    if (this.mutexQueue.length > 0) {
+      const resolve = this.mutexQueue.shift();
+      if (resolve) resolve();
+    } else {
+      this.isFetching = false;
+    }
+  }
+
+  static async buildSponsoredUsdcTrustlineXdr(
+    userAddress: string,
+  ): Promise<string> {
+    const sponsorSecret = process.env.STELLAR_SPONSOR_SECRET;
+    if (!sponsorSecret) {
+      throw new Error("STELLAR_SPONSOR_SECRET is not configured");
+    }
+
+    const usdcIssuer = process.env.STELLAR_USDC_ISSUER;
+    if (!usdcIssuer) {
+      throw new Error("STELLAR_USDC_ISSUER is not configured");
+    }
+
+    const sponsorKeypair = Keypair.fromSecret(sponsorSecret);
+    const networkPassphrase =
+      process.env.STELLAR_NETWORK_PASSPHRASE || Networks.TESTNET;
+    const usdcAsset = new Asset("USDC", usdcIssuer);
+
+    await this.lock();
+    try {
+      if (!this.sponsorAccount) {
+        const acc = await this.server.loadAccount(sponsorKeypair.publicKey());
+        this.sponsorAccount = new Account(acc.accountId(), acc.sequenceNumber());
+      }
+
+      const tx = new TransactionBuilder(this.sponsorAccount, {
+        fee: "300",
+        networkPassphrase,
+      })
+        .addOperation(
+          Operation.beginSponsoringFutureReserves({
+            sponsoredId: userAddress,
+            source: sponsorKeypair.publicKey(),
+          }),
+        )
+        .addOperation(
+          Operation.changeTrust({
+            asset: usdcAsset,
+            source: userAddress,
+          }),
+        )
+        .addOperation(
+          Operation.endSponsoringFutureReserves({
+            source: userAddress,
+          }),
+        )
+        .setTimeout(30)
+        .build();
+
+      tx.sign(sponsorKeypair);
+      return tx.toXDR();
+    } catch (error) {
+      this.sponsorAccount = null;
+      throw error;
+    } finally {
+      this.unlock();
+    }
   }
 }

--- a/backend/src/routes.ts
+++ b/backend/src/routes.ts
@@ -9,6 +9,7 @@ import {
 import { GET as walletBalanceGet } from "./api/wallet/balance/route";
 import { POST as walletDepositPost } from "./api/wallet/deposit";
 import { POST as walletWithdrawPost } from "./api/wallet/withdraw";
+import { POST as walletTrustlinePost } from "./api/wallet/trustline";
 
 // Streaming middleware to limit upload request size to 10MB without relying solely on Content-Length
 const limitUploadSize = (req: Request, res: Response, next: NextFunction) => {
@@ -164,3 +165,7 @@ apiRouter.delete("/api/users/account", makeExpressHandler(deleteAccountDelete));
 apiRouter.post("/api/wallet/register", makeExpressHandler(walletRegisterPost));
 apiRouter.post("/api/wallet/deposit", makeExpressHandler(walletDepositPost));
 apiRouter.post("/api/wallet/withdraw", makeExpressHandler(walletWithdrawPost));
+apiRouter.post(
+  "/api/wallet/trustline/usdc",
+  makeExpressHandler(walletTrustlinePost),
+);


### PR DESCRIPTION
Implement POST /api/wallet/trustline/usdc, which builds a Stellar transaction that lets a user establish a trustline to the USDC issuer without paying the trustline reserve themselves.

- Add TrustlineService.buildSponsoredUsdcTrustlineXdr, which builds a 3-operation transaction on the cached/mutex-guarded sponsor account: beginSponsoringFutureReserves (sponsor) -> changeTrust for USDC (user) -> endSponsoringFutureReserves (user), with the sponsor paying the fee and source account.
- Sign the envelope with the platform sponsor key (STELLAR_SPONSOR_SECRET) and return the partially-signed XDR so the mobile app can append the user's signature to the changeTrust and endSponsoringFutureReserves operations.
- Add the new POST /api/wallet/trustline/usdc endpoint, authenticated via getAuthPayload, resolving the caller's registered Stellar address and delegating to TrustlineService.
- Wire the route into routes.ts.
- Requires a new STELLAR_USDC_ISSUER env var (the USDC issuing account's public key).

Test plan:
- npx tsc --noEmit passes with no errors.
- Manually exercise POST /api/wallet/trustline/usdc against testnet with STELLAR_SPONSOR_SECRET and STELLAR_USDC_ISSUER configured, then verify the returned XDR decodes to the expected 3-operation envelope and submits successfully once the user's signature is appended.

Closes #377 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an endpoint to create a sponsored USDC trustline for a user’s Stellar wallet.
  * Requests now authenticate the wallet owner and return a transaction payload ready for signing.
  * Added clear responses for unauthenticated requests, missing wallet addresses, and processing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->